### PR TITLE
Corrections in Requirements page

### DIFF
--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -170,6 +170,9 @@ Conversely, in definition list syntax, not only components such as `part` and
 in the definition list. (In block attributes syntax, descriptive text is left
 as normal text.)
 
+The definition list may contain embedded levels [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.3];
+this is needed specifically for steps embedded within a test method.
+
 If you need to insert a cross-reference to a component, for example referencing
 a specific part of a requirement elsewhere, you can only use the block
 attributes sequence (as illustrated above).
@@ -191,6 +194,12 @@ subject:: system
 part:: Metadata models faithful to the original UML model.
 description:: Logical models encoded as XSDs should be faithful to the original UML conceptual
 models.
+test-method::
+step::: Step 1
+step::: Step 2
+step:::: Step 2a
+step:::: Step 2b
+step::: Step 3
 ====
 ----
 
@@ -729,6 +738,10 @@ Purpose_ [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.
 
 ** `test-method` (optional). Method of the test. Rich text. Presented as _Test
 Method_ [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.2]
+
+** `step` (optional). Step of the test method. Is expected to be embedded within `test-method`,
+and may contain substeps of its own. Rich text. Presented as a numbered list.
+added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.2]
 
 ** `test-method-type` (optional). Method of the test. Rich text. Presented as _Test
 Method Type_ [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.3]

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -245,7 +245,7 @@ to ModSpec [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.
 ** `requirement` for Requirement
 ** `recommendation` for Recommendation
 ** `permission` for Permission
-** `requirement_class` for Requirements class
+** `requirements_class` for Requirements class
 ** `conformance_test` for Conformance test
 ** `conformance_class` for Conformance class
 ** `abstract_test` for Abstract test
@@ -469,8 +469,8 @@ Logical Model UML defined in Section 8.
 [[reqt_class]]
 === Requirements class
 
-A "`Requirements class`" is encoded using `type` equals to `class` or `requirement_class`,
-or by setting the block style attribute to `requirement_class`.
+A "`Requirements class`" is encoded using `type` equals to `class` or `requirements_class`,
+or by setting the block style attribute to `requirements_class`.
 
 A Requirements class is cross-referenced and captioned as a
 "`{Requirement} class {N}`" [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v0.2.11].
@@ -497,7 +497,7 @@ EXAMPLE:
 .Example from OGC CityGML 3.0
 [source,asciidoc]
 ----
-[requirement_class,label="http://www.opengis.net/spec/CityGML-1/3.0/req/req-class-building",subject="Implementation Specification"]
+[requirements_class,label="http://www.opengis.net/spec/CityGML-1/3.0/req/req-class-building",subject="Implementation Specification"]
 ====
 [%metadata]
 inherit:: <<rc_core,/req/req-class-core>>
@@ -523,7 +523,7 @@ EXAMPLE:
 .Example from OGC GroundWaterML 2.0 (block attributes)
 [source,asciidoc]
 ----
-[requirement,type="requirement_class",obligation="requirement",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
+[requirement,type="requirements_class",obligation="requirement",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
 .GWML2 core logical model
 ====
 [%metadata]
@@ -591,7 +591,7 @@ same label [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.
 
 [source,asciidoc]
 ----
-[requirement_class,label="/req/conceptual"]
+[requirements_class,label="/req/conceptual"]
 .GWML2 core logical model
 ====
 

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -730,6 +730,9 @@ Purpose_ [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.
 ** `test-method` (optional). Method of the test. Rich text. Presented as _Test
 Method_ [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.2]
 
+** `test-method-type` (optional). Method of the test. Rich text. Presented as _Test
+Method Type_ [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.3]
+
 ** `reference` (optional). Purpose of the test. Rich text. Presented as _Reference_.
 
 * Test type of a Conformance test is encoded as a `classification` key-value pair.
@@ -757,7 +760,7 @@ subject:: <<req_core_classes,/req/core/classes>>
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test-method-type]
 --
 Manual Inspection
 --
@@ -787,7 +790,7 @@ type:: abstract_test
 label:: /ats/core/classes
 subject:: <<req_core_classes,/req/core/classes>>
 test-purpose:: To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
-test-method:: Manual Inspection
+test-method-type:: Manual Inspection
 description:: For each UML class defined or referenced in the Core Package:
 part:: Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 part:: Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicities as those documented in the Conceptual Model.
@@ -942,7 +945,7 @@ These are divided into two categories:
 extracted in order, with the class name normalised (title case), followed by the component contents.
 So a component with a `class` attribute of `conditions` will be rendered as
 _Conditions_ followed by the component contents. In the foregoing, we have seen components defined 
-in ModSpec: `test-purpose, test-method, conditions, reference`. However the block attribute
+in ModSpec: `test-purpose, test-method, test-method-type, conditions, reference`. However the block attribute
 syntax allows open-ended component names.
 
 *** Components with the `class` attribute `part` are extracted and presented in

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -524,14 +524,15 @@ attributes:
 * `subject`. Associated Requirement class. May be encoded as a cross-reference
 or as plain text. Rendered as _Requirement Class_.
 
-* `name`. Specified as the block caption.
-
 * `inherit` (optional). Dependencies of the conformance class. Accepts multiple
 semicolon-delimited values, which each could be a cross-reference to another
 conformance class or plain text.
 
-* `nesting` (optional). Conformance tests contained in a conformance class are
-encoded as conformance tests within the conformance class block.
+Conformance classes also feature:
+
+* Name (optional). Specified as the block caption.
+
+* Nesting (optional). Conformance tests contained in a conformance class are encoded as conformance tests within the conformance class block.
 
 NOTE: Conformance classes do not have a Target Type (as specified in ModSpec).
 If one must be encoded, it should be encoded as a Classification key-value
@@ -588,8 +589,6 @@ base ModSpec attributes:
 plain text. Multiple semicolon-delimited values may be provided. Rendered as
 _Requirement_.
 
-* `name`. Specified as the requirement's block caption.
-
 * `inherit` (optional). Dependencies. Accepts multiple semicolon-delimited
 values. Each may be a cross-reference or in plain text.
 
@@ -606,6 +605,10 @@ Method_ [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.2
 ** `reference` (optional). Purpose of the test. Rich text. Presented as _Reference_.
 
 * Test type of a Conformance test is encoded as a `classification` key-value pair.
+
+Conformance tests also feature:
+
+* Name (optional). Specified as the requirement's block caption.
 
 NOTE: Conformance Tests are excluded from the "`Table of Requirements`" in Word
 output [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v0.2.10].

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -219,12 +219,47 @@ list values; but this is not recommended, as it makes documents harder to mainta
 
 A ModSpec model encoding requires specifying the following attributes:
 
-* `type` (optional). One of:
+* `type` (optional). One of the following:
 ** `general` for Requirement, Recommendation or Permission (default value)
 ** `class` for Requirements class
 ** `verification` for Conformance test
 ** `conformanceclass` for Conformance class
 ** `abstracttest` for Abstract test
+
+The foregoing values are consistent with Metanorma's general design of requirements,
+and can be used in any flavour of Metanorma.
+The `type` attribute can also use the following values specific to metanorma-ogc as synomyms:
+these values are more closely aligned
+to ModSpec [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.3]:
+
+* `type` (optional). One of the following:
+** `requirement` for Requirement
+** `recommendation` for Recommendation
+** `permission` for Permission
+** `requirement_class` for Requirements class
+** `conformance_test` for Conformance test
+** `conformance_class` for Conformance class
+** `abstract_test` for Abstract test
+
+In addition, these values can be used instead of the Metanorma style labels, 
+to label requirement blocks. Again this is only valid within metanorma-ogc. So the
+following three
+encodings are equivalent:
+
+[source,asciidoc]
+----
+[.requirement,type=verification]
+----
+
+[source,asciidoc]
+----
+[.requirement,type=conformance_test]
+----
+
+[source,asciidoc]
+----
+[.conformance_test]
+----
 
 * `label` (mandatory). Label of the model, typically a URI. This must be unique
 in the document (as required by ModSpec), and is also used for referencing.
@@ -246,7 +281,7 @@ Differentiated types of ModSpec models allow additional attributes.
 === Requirement, recommendation, permission
 
 A Requirement (or Recommendation, Permission) is encoded by setting `type` to
-`general` (or by omitting the `type`).
+`general`, `requirement`, `recommendation`, or `permission` (or by omitting the `type`).
 
 It supports the following attributes in addition to base ModSpec attributes:
 
@@ -425,7 +460,8 @@ Logical Model UML defined in Section 8.
 [[reqt_class]]
 === Requirements class
 
-A "`Requirements class`" is encoded using `type` equals to `class`.
+A "`Requirements class`" is encoded using `type` equals to `class` or `requirement_class`,
+or by setting the block style attribute to `requirement_class`.
 
 A Requirements class is cross-referenced and captioned as a
 "`{Requirement} class {N}`" [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v0.2.11].
@@ -452,7 +488,7 @@ EXAMPLE:
 .Example from OGC CityGML 3.0
 [source,asciidoc]
 ----
-[requirement,type="class",label="http://www.opengis.net/spec/CityGML-1/3.0/req/req-class-building",subject="Implementation Specification"]
+[requirement_class,label="http://www.opengis.net/spec/CityGML-1/3.0/req/req-class-building",subject="Implementation Specification"]
 ====
 [%metadata]
 inherit:: <<rc_core,/req/req-class-core>>
@@ -478,7 +514,7 @@ EXAMPLE:
 .Example from OGC GroundWaterML 2.0 (block attributes)
 [source,asciidoc]
 ----
-[requirement,type="class",obligation="requirement",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
+[requirement,type="requirement_class",obligation="requirement",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
 .GWML2 core logical model
 ====
 [%metadata]
@@ -546,7 +582,7 @@ same label [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.
 
 [source,asciidoc]
 ----
-[requirement,type="class",label="/req/conceptual"]
+[requirement_class,label="/req/conceptual"]
 .GWML2 core logical model
 ====
 
@@ -587,7 +623,7 @@ ____
 
 === Conformance class
 
-Specified using `type` as `conformanceclass`.
+Specified using `type` as `conformanceclass` or `conformance_class`, or by setting the block style attribute to `conformance_class`.
 
 A Conformance class is cross-referenced and captioned as
 "`Conformance class {N}`", and is otherwise rendered identically to a
@@ -617,7 +653,7 @@ EXAMPLE:
 
 [source,asciidoc]
 ----
-[requirement,type="conformanceclass",label="http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs",inherit="http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#ats_core",classification="Target Type:Web API"]
+[conformance_class,label="http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs",inherit="http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#ats_core",classification="Target Type:Web API"]
 ====
 [%metadata]
 subject:: <<rc_crs,Requirements Class 'Coordinate Reference Systems by Reference'>>
@@ -629,7 +665,7 @@ subject:: <<rc_crs,Requirements Class 'Coordinate Reference Systems by Reference
 [requirement]
 ====
 [%metadata]
-type:: conformanceclass
+type:: conformance_class
 label:: http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs
 subject:: <<rc_crs,Requirements Class 'Coordinate Reference Systems by Reference'>>
 inherit:: http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#ats_core
@@ -662,11 +698,13 @@ The OGC author should identify whether a standard requires an "`Abstract test
 suite`" or a "`Conformance test suite`" in order to decide the encoding of
 "`Conformance tests`" (concrete tests) versus "`Abstract tests`".
 
-* A conformance test is specified using `type` as `verification`, and
-cross-referenced as "`Conformance test {N}`"
+* A conformance test is specified using `type` as `verification` or `conformance_test`, or
+by setting its style attribute to `conformance_test`.
+It is cross-referenced as "`Conformance test {N}`"
 
-* An abstract test is specified using `type` as `abstracttest`, and
-cross-referenced as "`Abstract test {N}`" [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.0.4].
+* An abstract test is specified using `type` as `abstracttest` or `abstract_test`, or
+by setting its style attribute to `abstract_test`.
+It is cross-referenced as "`Abstract test {N}`" [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.0.4].
 
 // NOTE: Verifications for Recommendations will be captioned as
 // Recommendation Tests, similarly for Requirement Tests and
@@ -709,7 +747,7 @@ EXAMPLE:
 [source,adoc]
 ----
 [[ats_core_classes]]
-[requirement,type="abstracttest",label="/ats/core/classes"]
+[abstract_test,label="/ats/core/classes"]
 ====
 [%metadata]
 subject:: <<req_core_classes,/req/core/classes>>
@@ -745,7 +783,7 @@ Validate that the data element has the same relationships with other elements as
 [requirement]
 ====
 [%metadata]
-type:: abstracttest
+type:: abstract_test
 label:: /ats/core/classes
 subject:: <<req_core_classes,/req/core/classes>>
 test-purpose:: To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
@@ -794,10 +832,9 @@ https://tools.ietf.org/html/rfc3986#section-3[RFC 3986, section 3].
 .Example of Abstract test from DGGS (definitions list)
 [source,asciidoc]
 ----
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/crs/crs-uri
 subject:: <<req_crs_crs-uri,/req/crs/crs-uri>>
 subject:: <<req_crs_fc-md-crs-list_A,/req/crs/fc-md-crs-list A>>

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -134,11 +134,13 @@ The extension of the definition lists syntax to components is specific to the OG
 
 In Metanorma, the following two encoding syntaxes are considered equivalent.
 
-* In definition list syntax, a `[%metadata]` definition list within a ModSpec
-model provides the necessary information for the specified model.
-
 * In block attributes syntax, the necessary information is provided as an
-attribute list to the block.
+attribute list to the block. This follows the usual norms for Asciidoctor syntax, 
+but it restricts attribute values to be plain text.
+
+* In definition list syntax, a `[%metadata]` definition list within a ModSpec
+model provides the necessary information for the specified model. The values given 
+in the definition list syntax can be fully formatted Metanorma text.
 
 Attributes that can take Rich textual input, such as `part` and `conditions`, are
 components of requirements in Metanorma: these are
@@ -449,6 +451,9 @@ inherit:: <<rc_construction,/req/req-class-construction>>
 ====
 ----
 
+Note that in this example, both block attributes and definition list syntax is used;
+the `inherit` attribute has two hyperlink values, which are expressed in the definition list.
+
 // TODO: Add rendering example
 
 A requirements class can contain multiple requirements, specified with embedded
@@ -464,9 +469,11 @@ EXAMPLE:
 .Example from OGC GroundWaterML 2.0 (block attributes)
 [source,asciidoc]
 ----
-[requirement,type="class",label="http://www.opengis.net/spec/waterml/2.0/req/xsd-xml-rules[*req/core*]",obligation="requirement",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
+[requirement,type="class",obligation="requirement",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
 .GWML2 core logical model
 ====
+[%metadata]
+label:: http://www.opengis.net/spec/waterml/2.0/req/xsd-xml-rules[*req/core*]
 
 [requirement,type="general",label="/req/core/encoding"]
 ======
@@ -477,6 +484,8 @@ EXAMPLE:
 ======
 ====
 ----
+
+(Again, note that the hyperlink in the `label` attribute needs to be given as a definition list value.)
 
 .Example from OGC GroundWaterML 2.0 (definition list)
 [source,asciidoc]
@@ -599,8 +608,10 @@ EXAMPLE:
 
 [source,asciidoc]
 ----
-[requirement,type="conformanceclass",label="http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs",subject="<<rc_crs,Requirements Class 'Coordinate Reference Systems by Reference'>>",inherit="http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#ats_core",classification="Target Type:Web API"]
+[requirement,type="conformanceclass",label="http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs",inherit="http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#ats_core",classification="Target Type:Web API"]
 ====
+[%metadata]
+subject:: <<rc_crs,Requirements Class 'Coordinate Reference Systems by Reference'>>
 ====
 ----
 
@@ -689,8 +700,11 @@ EXAMPLE:
 [source,adoc]
 ----
 [[ats_core_classes]]
-[requirement,type="abstracttest",label="/ats/core/classes",subject='<<req_core_classes,/req/core/classes>>']
+[requirement,type="abstracttest",label="/ats/core/classes"]
 ====
+[%metadata]
+subject:: <<req_core_classes,/req/core/classes>>
+
 [.component,class=test-purpose]
 --
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
@@ -736,8 +750,13 @@ part:: Validate that the data element has the same relationships with other elem
 .Example of Abstract test from DGGS (block attributes)
 [source,asciidoc]
 ----
-[requirement,type="abstracttest",label="/conf/crs/crs-uri",subject="<<req_crs_crs-uri,/req/crs/crs-uri>>,<<req_crs_fc-md-crs-list_A,/req/crs/fc-md-crs-list A>>,<<req_crs_fc-md-storageCrs,/req/crs/fc-md-storageCrs>>,<<req_crs_fc-md-crs-list-global,/req/crs/fc-md-crs-list-global>>",classification="Test Type:Basic"]
+[requirement,type="abstracttest",label="/conf/crs/crs-uri",classification="Test Type:Basic"]
 ====
+[%metadata]
+subject:: <<req_crs_crs-uri,/req/crs/crs-uri>>
+subject:: <<req_crs_fc-md-crs-list_A,/req/crs/fc-md-crs-list A>>
+subject:: <<req_crs_fc-md-storageCrs,/req/crs/fc-md-storageCrs>>
+subject:: <<req_crs_fc-md-crs-list-global,/req/crs/fc-md-crs-list-global>>"
 
 [.component,class=test-purpose]
 --

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -127,29 +127,32 @@ but some authors may prefer specifying attributes in the header.
 
 NOTE: These two methods originate from Metanorma's general support of the
 alternative syntaxes for specifying a block attribute list as a definition list.
-The extension of the definition lists syntax to components is specific to the OGC flavour.
+The extension of the definition lists syntax to components is specific to
+Metanorma OGC.
 
 
 === Specifying using definition lists or block attributes
 
 In Metanorma, the following two encoding syntaxes are considered equivalent.
 
-* In block attributes syntax, the necessary information is provided as an
-attribute list to the block. This follows the usual norms for Asciidoctor syntax, 
-but it restricts attribute values to be plain text.
+* In the *block attributes* syntax, the necessary information is provided as an
+attribute list to the block.
+Values contained in the attribute list must be in plain text.
 
-* In definition list syntax, a `[%metadata]` definition list within a ModSpec
-model provides the necessary information for the specified model. The values given 
-in the definition list syntax can be fully formatted Metanorma text.
+* In the *definition list* syntax, a `[%metadata]` definition list within a
+ModSpec model provides the necessary information for the specified model.
+Values given in the definition list syntax can be fully-formatted Metanorma
+AsciiDoc text.
 
-Attributes that can take Rich textual input, such as `part` and `conditions`, are
-components of requirements in Metanorma: these are
+Attributes that can take rich textual input (Metanorma AsciiDoc input), such as
+`part` and `conditions`, are components of requirements in Metanorma: these are
 encoded in the block attributes syntax using the `[.component]` role within the
-ModSpec model block, on open blocks or example blocks, as in:
+ModSpec model block, on open blocks or example blocks.
+
+EXAMPLE:
 
 [source,adoc]
 ----
-[[part_a_of_requirement]]
 [.component,class=part]
 --
 Part A of the requirement.
@@ -158,7 +161,6 @@ Part A of the requirement.
 
 [source,adoc]
 ----
-[[part_a_of_requirement]]
 [.component,class=part]
 ====
 Part A of the requirement.
@@ -188,12 +190,12 @@ identically in output).
 .Encoding of logical models
 ====
 [%metadata]
-type:: general
 label:: ogc/spec/waterml/2.0/req/xsd-xml-rules
 subject:: system
 part:: Metadata models faithful to the original UML model.
-description:: Logical models encoded as XSDs should be faithful to the original UML conceptual
-models.
+description:: Logical models encoded as XSDs should be faithful to the original
+UML conceptual models.
+
 test-method::
 step::: Step 1
 step::: Step 2
@@ -204,9 +206,9 @@ step::: Step 3
 ----
 
 [source,asciidoc]
-.ModSpec requirement in attribute list syntax
+.ModSpec requirement in block attributes syntax
 ----
-[requirement,type="general",label="ogc/spec/waterml/2.0/req/xsd-xml-rules",subject="system"]
+[requirement,label="ogc/spec/waterml/2.0/req/xsd-xml-rules",subject="system"]
 .Encoding of logical models
 ====
 
@@ -215,59 +217,69 @@ step::: Step 3
 Metadata models faithful to the original UML model.
 --
 
+[.component,class=test-method]
+-----
+[.component,class=step]
+------
+Step 1
+------
+
+[.component,class=step]
+------
+Step 2
+
+[.component,class=step]
+-------
+Step 2a
+-------
+
+[.component,class=step]
+-------
+Step 2b
+-------
+------
+
+[.component,class=step]
+------
+Step 3
+------
+-----
+
 Logical models encoded as XSDs should be faithful to the original UML conceptual
 models.
 ====
 ----
 
-The two syntaxes can be mixed, with the definition list values following the block attribute
-list values; but this is not recommended, as it makes documents harder to maintain.
+These two syntaxes can be mixed.
 
 
-=== Base ModSpec model attributes
+=== ModSpec model attributes
 
-A ModSpec model encoding requires specifying the following attributes:
+A ModSpec model is encoded with one of these block types:
 
-* `type` (optional). One of the following:
-** `general` for Requirement, Recommendation or Permission (default value)
-** `class` for Requirements class
-** `verification` for Conformance test
-** `conformanceclass` for Conformance class
-** `abstracttest` for Abstract test
+* `[requirement]` for Requirement
+* `[recommendation]` for Recommendation
+* `[permission]` for Permission
+* `[requirements_class]` for Requirements class
+* `[conformance_test]` for Conformance test
+* `[conformance_class]` for Conformance class
+* `[abstract_test]` for Abstract test
 
-The foregoing values are consistent with Metanorma's general design of requirements,
-and can be used in any flavour of Metanorma.
-The `type` attribute can also use the following values specific to metanorma-ogc as synomyms:
-these values are more closely aligned
-to ModSpec [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.3]:
+NOTE: These ModSpec types are available from [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.3]
 
-* `type` (optional). One of the following:
-** `requirement` for Requirement
-** `recommendation` for Recommendation
-** `permission` for Permission
-** `requirements_class` for Requirements class
-** `conformance_test` for Conformance test
-** `conformance_class` for Conformance class
-** `abstract_test` for Abstract test
+In addition, if the Metanorma generic `[requirements]` block is used, these
+values are to be used in the `type` attribute.
 
-In addition, these values can be used instead of the Metanorma style labels, 
-to label requirement blocks. Again this is only valid within metanorma-ogc. So the
-following three
-encodings are equivalent:
+The following two encodings are equivalent:
 
 [source,asciidoc]
 ----
-[.requirement,type=verification]
+[conformance_test]
 ----
 
 [source,asciidoc]
 ----
-[.requirement,type=conformance_test]
-----
-
-[source,asciidoc]
-----
-[.conformance_test]
+[requirement,type=conformance_test]
 ----
 
 * `label` (mandatory). Label of the model, typically a URI. This must be unique
@@ -281,20 +293,19 @@ Plain text.
 ** `recommendation`
 ** `permission`
 
-* `model` (optional when using Metanorma OGC). Type of model. The value of `ogc`
-means using OGC ModSpec models.
+// * `model` (optional when using Metanorma OGC). Type of model. The value of `ogc`
+// means using OGC ModSpec models.
 
 Differentiated types of ModSpec models allow additional attributes.
 
 [[general]]
 === Requirement, recommendation, permission
 
-A Requirement (or Recommendation, Permission) is encoded by setting `type` to
-`general`, `requirement`, `recommendation`, or `permission` (or by omitting the `type`).
+A Requirement (or Recommendation, Permission) is encoded as a `requirement`,
+`recommendation`, or `permission` block or by setting `type` to `requirement`,
+`recommendation`, or `permission`.
 
 It supports the following attributes in addition to base ModSpec attributes:
-
-* `type` specified as `general`
 
 * `conditions` (optional). Conditions on where this requirement applies. Accepts
 rich text.
@@ -303,10 +314,10 @@ rich text.
 sub-requirements. Accepts rich text.
 
 * `inherit` (optional). A requirement can inherit from one or more requirements.
-Accepts cross-references to other requirement models, or plain text.
-In block attributes syntax, accepts multiple
-semicolon-delimited values, which each could be a cross-reference to another
-conformance class or plain text. Can be repeated in definition list syntax.
+Accepts cross-references to other requirement models, or plain text. In block
+attributes syntax, accepts multiple semicolon-delimited values, which each could
+be a cross-reference to another conformance class or plain text. Can be repeated
+in definition list syntax.
 
 * `classification` (optional). Classification of this requirement.
 The `classification` attribute is marked up as in the rest of Metanorma:
@@ -320,7 +331,7 @@ EXAMPLE:
 [source,asciidoc]
 .OGC CityGML 3.0 sample requirement with two parts (block attributes)
 ----
-[requirement,type="general",label="/req/relief/classes"]
+[requirement,label="/req/relief/classes"]
 ====
 For each UML class defined or referenced in the Relief Package:
 
@@ -344,7 +355,6 @@ source, target, direction, roles, and multiplicities as those of the UML class.
 [requirement]
 ====
 [%metadata]
-type:: general
 label:: /req/relief/classes
 description:: For each UML class defined or referenced in the Relief Package:
 part:: The Implementation Specification SHALL contain an element which represents the
@@ -357,7 +367,7 @@ source, target, direction, roles, and multiplicities as those of the UML class.
 [source,asciidoc]
 .OGC GroundWaterML 2.0 sample requirement
 ----
-[requirement,type="general",id="/req/core/encoding",label="/req/core/encoding"]
+[requirement,id="/req/core/encoding",label="/req/core/encoding"]
 ====
 All target implementations SHALL conform to the appropriate GroundWaterML2
 Logical Model UML defined in Section 8.
@@ -469,8 +479,8 @@ Logical Model UML defined in Section 8.
 [[reqt_class]]
 === Requirements class
 
-A "`Requirements class`" is encoded using `type` equals to `class` or `requirements_class`,
-or by setting the block style attribute to `requirements_class`.
+A "`Requirements class`" is encoded as a block of `requirements_class` or using
+`type` equals to `requirements_class`.
 
 A Requirements class is cross-referenced and captioned as a
 "`{Requirement} class {N}`" [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v0.2.11].
@@ -497,15 +507,17 @@ EXAMPLE:
 .Example from OGC CityGML 3.0
 [source,asciidoc]
 ----
-[requirements_class,label="http://www.opengis.net/spec/CityGML-1/3.0/req/req-class-building",subject="Implementation Specification"]
+[requirements_class]
 ====
 [%metadata]
+label:: http://www.opengis.net/spec/CityGML-1/3.0/req/req-class-building
+subject:: Implementation Specification
 inherit:: <<rc_core,/req/req-class-core>>
 inherit:: <<rc_construction,/req/req-class-construction>>
 ====
 ----
 
-Note that in this example, both block attributes and definition list syntax is used;
+NOTE: In this example, both block attributes and definition list syntax is used;
 the `inherit` attribute has two hyperlink values, which are expressed in the definition list.
 
 // TODO: Add rendering example
@@ -523,32 +535,32 @@ EXAMPLE:
 .Example from OGC GroundWaterML 2.0 (block attributes)
 [source,asciidoc]
 ----
-[requirement,type="requirements_class",obligation="requirement",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
+[requirements_class,inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
 .GWML2 core logical model
 ====
 [%metadata]
+subject:: Encoding of logical models
 label:: http://www.opengis.net/spec/waterml/2.0/req/xsd-xml-rules[*req/core*]
 
-[requirement,type="general",label="/req/core/encoding"]
+[requirement,label="/req/core/encoding"]
 ======
 ======
 
-[requirement,type="general",label="/req/core/quantities-uom"]
+[requirement,label="/req/core/quantities-uom"]
 ======
 ======
 ====
 ----
 
-(Again, note that the hyperlink in the `label` attribute needs to be given as a definition list value.)
+//NOTE: The hyperlink in the `label` attribute needs to be given as a definition list value.
 
 .Example from OGC GroundWaterML 2.0 (definition list)
 [source,asciidoc]
 ----
-[requirement]
+[requirements_class]
 .GWML2 core logical model
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/waterml/2.0/req/xsd-xml-rules[*req/core*]
 obligation:: requirement
 subject:: Encoding of logical models
@@ -595,13 +607,13 @@ same label [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.
 .GWML2 core logical model
 ====
 
-[requirement,type="general",label="/req/core/encoding"]
+[requirement,label="/req/core/encoding"]
 ======
 ======
 
 ====
 
-[requirement,type="general",label="/req/core/encoding"]
+[requirement,label="/req/core/encoding"]
 ====
 Encoding requirement
 ====
@@ -632,7 +644,8 @@ ____
 
 === Conformance class
 
-Specified using `type` as `conformanceclass` or `conformance_class`, or by setting the block style attribute to `conformance_class`.
+Specified by setting the block as `conformance_class` or by using `type` as
+`conformance_class`.
 
 A Conformance class is cross-referenced and captioned as
 "`Conformance class {N}`", and is otherwise rendered identically to a
@@ -641,8 +654,8 @@ A Conformance class is cross-referenced and captioned as
 Conformance classes support the following attributes in addition to base ModSpec
 attributes:
 
-* `subject`. Associated Requirement class. May be encoded as a cross-reference
-or as plain text. Rendered as _Requirement Class_.
+* `subject`. Associated Requirements class. May be encoded as a cross-reference
+or as plain text. Rendered as _Requirements Class_.
 
 * `inherit` (optional). Dependencies of the conformance class. Accepts multiple
 values, which each could be a cross-reference to another
@@ -652,10 +665,12 @@ Conformance classes also feature:
 
 * Name (optional). Specified as the block caption.
 
-* Nesting (optional). Conformance tests contained in a conformance class are encoded as conformance tests within the conformance class block. See <<reqt_class,Requirements class>>.
+* Nesting (optional). Conformance tests contained in a conformance class are
+encoded as conformance tests within the conformance class block.
+See <<reqt_class,Requirements class>>.
 
 NOTE: Conformance classes do not have a Target Type (as specified in ModSpec).
-If one must be encoded, it should be encoded as a Classification key-value
+If one must be encoded, it should be encoded as a classification key-value
 pair.
 
 EXAMPLE:
@@ -671,10 +686,9 @@ subject:: <<rc_crs,Requirements Class 'Coordinate Reference Systems by Reference
 
 [source,asciidoc]
 ----
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformance_class
 label:: http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs
 subject:: <<rc_crs,Requirements Class 'Coordinate Reference Systems by Reference'>>
 inherit:: http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#ats_core
@@ -707,12 +721,13 @@ The OGC author should identify whether a standard requires an "`Abstract test
 suite`" or a "`Conformance test suite`" in order to decide the encoding of
 "`Conformance tests`" (concrete tests) versus "`Abstract tests`".
 
-* A conformance test is specified using `type` as `verification` or `conformance_test`, or
-by setting its style attribute to `conformance_test`.
+* A conformance test is specified by creating a `conformance_test` block or
+using `type` as `conformance_test`.
 It is cross-referenced as "`Conformance test {N}`"
 
-* An abstract test is specified using `type` as `abstracttest` or `abstract_test`, or
-by setting its style attribute to `abstract_test`.
+* An abstract test is specified by creating an `abstract_test` block or using
+`type` as `abstract_test`, or `conformance_test` together with
+`abstract=true`.
 It is cross-referenced as "`Abstract test {N}`" [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.0.4].
 
 // NOTE: Verifications for Recommendations will be captioned as
@@ -726,7 +741,8 @@ base ModSpec attributes:
 plain text. Multiple semicolon-delimited values may be provided. Rendered as
 _Requirement_.
 
-* `inherit` (optional). Dependencies. Accepts multiple values. Each may be a cross-reference or in plain text.
+* `inherit` (optional). Dependencies. Accepts multiple values.
+Each may be a cross-reference or in plain text.
 See <<general,Requirement, recommendation, permission>>.
 
 * Components (optional). Components of the conformance test. Accepts rich
@@ -762,7 +778,6 @@ EXAMPLE:
 .Example of Abstract test from CityGML 3.0 (block attributes)
 [source,adoc]
 ----
-[[ats_core_classes]]
 [abstract_test,label="/ats/core/classes"]
 ====
 [%metadata]
@@ -770,7 +785,8 @@ subject:: <<req_core_classes,/req/core/classes>>
 
 [.component,class=test-purpose]
 --
-To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
+To validate that the Implementation Specification correctly implements the UML
+Classes defined in the Conceptual Model.
 --
 
 [.component,class=test-method-type]
@@ -782,12 +798,16 @@ For each UML class defined or referenced in the Core Package:
 
 [.component,class=part]
 --
-Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
+Validate that the Implementation Specification contains a data element which
+represents the same concept as that defined for the UML class.
 --
 
 [.component,class=part]
 --
-Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicities as those documented in the Conceptual Model.
+Validate that the data element has the same relationships with other elements as
+those defined for the UML class. Validate that those relationships have the same
+source, target, direction, roles, and multiplicities as those documented in the
+Conceptual Model.
 --
 ====
 ----
@@ -795,25 +815,34 @@ Validate that the data element has the same relationships with other elements as
 .Example of Abstract test from CityGML 3.0 (definition list)
 [source,adoc]
 ----
-[[ats_core_classes]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstract_test
 label:: /ats/core/classes
+
 subject:: <<req_core_classes,/req/core/classes>>
-test-purpose:: To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
+
+test-purpose:: To validate that the Implementation Specification correctly
+implements the UML Classes defined in the Conceptual Model.
+
 test-method-type:: Manual Inspection
+
 description:: For each UML class defined or referenced in the Core Package:
-part:: Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
-part:: Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicities as those documented in the Conceptual Model.
+
+part:: Validate that the Implementation Specification contains a data element
+which represents the same concept as that defined for the UML class.
+
+part:: Validate that the data element has the same relationships with other
+elements as those defined for the UML class. Validate that those relationships
+have the same source, target, direction, roles, and multiplicities as those
+documented in the Conceptual Model.
 ====
 ----
 
 .Example of Abstract test from DGGS (block attributes)
 [source,asciidoc]
 ----
-[requirement,type="abstracttest",label="/conf/crs/crs-uri",classification="Test Type:Basic"]
+[abstract_test,label="/conf/crs/crs-uri",classification="Test Type:Basic"]
 ====
 [%metadata]
 subject:: <<req_crs_crs-uri,/req/crs/crs-uri>>
@@ -900,27 +929,27 @@ ____
 
 == Rendering of ModSpec models
 
-OGC ModSpec models are generally rendered as tables.
+OGC ModSpec models are rendered as tables.
 
 NOTE: This rendering method is consistent with prior OGC practice.
 
-* For HTML rendering, the CSS class of the requirement table is the `type`
-attribute of the requirement.
+* For HTML rendering, the CSS class of the ModSpec specification table is the
+`type` attribute of the requirement.
 +
 --
 The following types are recognised:
 
 ** No value for Requirements
-** `verification` for Conformance tests
-** `abstracttest` for Abstract tests
-** `class` for Requirements classes
-** `conformanceclass` for Conformance classes
+** `conformance_test` for Conformance tests
+** `abstract_test` for Abstract tests
+** `requirements_class` for Requirements classes
+** `conformance_class` for Conformance classes
 
 The default CSS class currently assigned for HTML rendering is `recommend`.
 --
 
 * The heading of the table (spanning two columns) is its name (the role
-or style of the requirement, e.g. `[.permission]` or `[permission]`), optionally
+or style of the requirement, e.g. `[permission]` or `[.permission]`), optionally
 followed by its title (the caption of the requirement, e.g. `.Title`).
 
 * The title of the table (spanning two columns) is its `label` attribute.
@@ -957,7 +986,7 @@ These are divided into two categories:
 *** Components with a `class` attribute other than `part` are
 extracted in order, with the class name normalised (title case), followed by the component contents.
 So a component with a `class` attribute of `conditions` will be rendered as
-_Conditions_ followed by the component contents. In the foregoing, we have seen components defined 
+_Conditions_ followed by the component contents. In the foregoing, we have seen components defined
 in ModSpec: `test-purpose, test-method, test-method-type, conditions, reference`. However the block attribute
 syntax allows open-ended component names.
 
@@ -1013,3 +1042,13 @@ the document SHOULD conform to the
 |===
 ----
 ====
+
+== Legacy ModSpec type keywords
+
+These values for the ModSpec model type have been deprecated:
+
+* `general` for Requirement, Recommendation or Permission (now `requirement`, `recommendation` or `permission`)
+* `class` for Requirements class (now `requirements_class`)
+* `verification` for Conformance test (now `conformance_test`)
+* `conformanceclass` for Conformance class (now `conformance_class`)
+* `abstracttest` for Abstract test (now `abstract_test`)

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -91,7 +91,7 @@ type of conformance test suite (see https://portal.ogc.org/files/?artifact_id=34
 while an abstract conformance test is called an "`abstract test`".
 
 * A "`Test suite`" is "`a collection of identifiable conformance classes`"
-(see OGC 08-131r3, 6.4)
+(see https://portal.ogc.org/files/?artifact_id=34762[OGC 08-131r3], 6.4)
 
 ** A "`Conformance test suite`" contains only "`Conformance classes`" of the
 "`concrete`" kind. Such conformance class can only contain "`concrete`"
@@ -175,7 +175,7 @@ models.
 [source,asciidoc]
 .ModSpec requirement in attribute list syntax
 ----
-[requirement,type=general,label=ogc/spec/waterml/2.0/req/xsd-xml-rules,subject="system"]
+[requirement,type="general",label="ogc/spec/waterml/2.0/req/xsd-xml-rules",subject="system"]
 .Encoding of logical models
 ====
 
@@ -524,13 +524,13 @@ attributes:
 * `subject`. Associated Requirement class. May be encoded as a cross-reference
 or as plain text. Rendered as _Requirement Class_.
 
-* Name. Specified as the block caption.
+* `name`. Specified as the block caption.
 
 * `inherit` (optional). Dependencies of the conformance class. Accepts multiple
 semicolon-delimited values, which each could be a cross-reference to another
 conformance class or plain text.
 
-* Nesting (optional). Conformance tests contained in a conformance class are
+* `nesting` (optional). Conformance tests contained in a conformance class are
 encoded as conformance tests within the conformance class block.
 
 NOTE: Conformance classes do not have a Target Type (as specified in ModSpec).
@@ -565,7 +565,7 @@ ____
 === Conformance test and Abstract test
 
 A "`Conformance test`" can be "`concrete`" or "`abstract`" depending on the type
-of conformance test suite (ModSpec, 6.4).
+of conformance test suite (see https://portal.ogc.org/files/?artifact_id=34762[OGC 08-131r3], 6.4).
 
 The OGC author should identify whether a standard requires an "`Abstract test
 suite`" or a "`Conformance test suite`" in order to decide the encoding of
@@ -588,7 +588,7 @@ base ModSpec attributes:
 plain text. Multiple semicolon-delimited values may be provided. Rendered as
 _Requirement_.
 
-* Name. Specified as the requirement's block caption.
+* `name`. Specified as the requirement's block caption.
 
 * `inherit` (optional). Dependencies. Accepts multiple semicolon-delimited
 values. Each may be a cross-reference or in plain text.

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -127,6 +127,7 @@ but some authors may prefer specifying attributes in the header.
 
 NOTE: These two methods originate from Metanorma's general support of the
 alternative syntaxes for specifying a block attribute list as a definition list.
+The extension of the definition lists syntax to components is specific to the OGC flavour.
 
 
 === Specifying using definition lists or block attributes
@@ -139,17 +140,28 @@ model provides the necessary information for the specified model.
 * In block attributes syntax, the necessary information is provided as an
 attribute list to the block.
 
-Rich textual input to attributes, such as for `part` and `component`, are
+Attributes that can take Rich textual input, such as `part` and `conditions`, are
+components of requirements in Metanorma: these are
 encoded in the block attributes syntax using the `[.component]` role within the
 ModSpec model block, as in:
 
 [source,adoc]
 ----
+[[part_a_of_requirement]]
 [.component,class=part]
 --
 Part A of the requirement.
 --
 ----
+
+Conversely, in definition list syntax, not only components such as `part` and
+`conditions`, but also `description` for descriptive text, can be specified
+in the definition list. (In block attributes syntax, descriptive text is left
+as normal text.)
+
+If you need to insert a cross-reference to a component, for example referencing
+a specific part of a requirement elsewhere, you can only use the block
+attributes sequence (as illustrated above).
 
 The following two examples demonstrate encoding of a ModSpec requirement
 that are encoded in Metanorma XML identically (and therefore rendered
@@ -166,8 +178,7 @@ type:: general
 label:: ogc/spec/waterml/2.0/req/xsd-xml-rules
 subject:: system
 part:: Metadata models faithful to the original UML model.
-
-Logical models encoded as XSDs should be faithful to the original UML conceptual
+description:: Logical models encoded as XSDs should be faithful to the original UML conceptual
 models.
 ====
 ----
@@ -189,15 +200,16 @@ models.
 ====
 ----
 
-// TODO: Can we mix syntaxes?
+The two syntaxes can be mixed, with the definition list values following the block attribute
+list values; but this is not recommended, as it makes documents harder to maintain.
 
 
 === Base ModSpec model attributes
 
 A ModSpec model encoding requires specifying the following attributes:
 
-* `type` (mandatory). One of:
-** `general` for Requirement, Recommendation or Permission
+* `type` (optional). One of:
+** `general` for Requirement, Recommendation or Permission (default value)
 ** `class` for Requirements class
 ** `verification` for Conformance test
 ** `conformanceclass` for Conformance class
@@ -219,11 +231,11 @@ means using OGC ModSpec models.
 
 Differentiated types of ModSpec models allow additional attributes.
 
-
+[[general]]
 === Requirement, recommendation, permission
 
 A Requirement (or Recommendation, Permission) is encoded by setting `type` to
-`general`.
+`general` (or by omitting the `type`).
 
 It supports the following attributes in addition to base ModSpec attributes:
 
@@ -237,15 +249,21 @@ sub-requirements. Accepts rich text.
 
 * `inherit` (optional). A requirement can inherit from one or more requirements.
 Accepts cross-references to other requirement models, or plain text.
+In block attributes syntax, accepts multiple
+semicolon-delimited values, which each could be a cross-reference to another
+conformance class or plain text. Can be repeated in definition list syntax.
 
 * `classification` (optional). Classification of this requirement.
+The `classification` attribute is marked up as in the rest of Metanorma:
+`key1=value1;key2=value2...`, where _value_ is either a single
+string, or a comma-delimited list of values.
 
 NOTE: Support for `conditions`, `part` [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.2].
 
 EXAMPLE:
 
 [source,asciidoc]
-.OGC CityGML 3.0 sample requirement with two parts
+.OGC CityGML 3.0 sample requirement with two parts (block attributes)
 ----
 [requirement,type="general",label="/req/relief/classes"]
 ====
@@ -262,6 +280,22 @@ same concept as that defined for the UML class.
 The Implementation Specification SHALL represent associations with the same
 source, target, direction, roles, and multiplicities as those of the UML class.
 --
+====
+----
+
+[source,asciidoc]
+.OGC CityGML 3.0 sample requirement with two parts (definition list)
+----
+[requirement]
+====
+[%metadata]
+type:: general
+label:: /req/relief/classes
+description:: For each UML class defined or referenced in the Relief Package:
+part:: The Implementation Specification SHALL contain an element which represents the
+same concept as that defined for the UML class.
+part:: The Implementation Specification SHALL represent associations with the same
+source, target, direction, roles, and multiplicities as those of the UML class.
 ====
 ----
 
@@ -377,6 +411,7 @@ Logical Model UML defined in Section 8.
 // ____
 
 
+[[reqt_class]]
 === Requirements class
 
 A "`Requirements class`" is encoded using `type` equals to `class`.
@@ -396,8 +431,7 @@ block caption.
 
 * `subject` (mandatory). The Target Type. Rendered as _Target Type_.
 
-* `inherit` (optional). Dependent requirements classes. Multiple
-semicolon-delimited values are allowed.
+* `inherit` (optional). Dependent requirements classes. See <<general,Requirement, recommendation, permission>>.
 
 * Embedded requirements (optional). Requirements contained in a class are marked
 up as nested requirements.
@@ -409,8 +443,9 @@ EXAMPLE:
 ----
 [requirement,type="class",label="http://www.opengis.net/spec/CityGML-1/3.0/req/req-class-building",subject="Implementation Specification"]
 ====
-inherit:[<<rc_core,/req/req-class-core>>]
-inherit:[<<rc_construction,/req/req-class-construction>>]
+[%metadata]
+inherit:: <<rc_core,/req/req-class-core>>
+inherit:: <<rc_construction,/req/req-class-construction>>
 ====
 ----
 
@@ -421,11 +456,12 @@ requirements.
 
 The contents of these embedded requirements may be specified within the
 requirements class, or specified outside of the requirements class (referenced
-using the label).
+using the label). If the requirement is specified within a definition list,
+the definition list value is interpreted as the requirement label
 
 EXAMPLE:
 
-.Example from OGC GroundWaterML 2.0
+.Example from OGC GroundWaterML 2.0 (block attributes)
 [source,asciidoc]
 ----
 [requirement,type="class",label="http://www.opengis.net/spec/waterml/2.0/req/xsd-xml-rules[*req/core*]",obligation="requirement",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used"]
@@ -439,6 +475,27 @@ EXAMPLE:
 [requirement,type="general",label="/req/core/quantities-uom"]
 ======
 ======
+====
+----
+
+.Example from OGC GroundWaterML 2.0 (definition list)
+[source,asciidoc]
+----
+[requirement]
+.GWML2 core logical model
+====
+[%metadata]
+type:: class
+label:: http://www.opengis.net/spec/waterml/2.0/req/xsd-xml-rules[*req/core*]
+obligation:: requirement
+subject:: Encoding of logical models
+inherit:: urn:iso:dis:iso:19156:clause:7.2.2
+inherit:: urn:iso:dis:iso:19156:clause:8
+inherit:: http://www.opengis.net/doc/IS/GML/3.2/clause/2.4
+inherit:: O&M Abstract model, OGC 10-004r3, clause D.3.4
+inherit:: http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used
+requirement:: /req/core/encoding
+requirement:: /req/core/quantities-uom
 ====
 ----
 
@@ -495,12 +552,12 @@ ____
 2+| *Requirement Class 3: GWML2 core logical model* +
 /req/conceptual
 
-| Requirement 1:   | /req/core/encoding
+| Requirement 1   | /req/core/encoding
 |===
 
 [cols="1,3"]
 |===
-2+|*Requirement 1:*
+2+|*Requirement 1*
 /req/core/encoding
 
 2+| Encoding requirement
@@ -525,14 +582,14 @@ attributes:
 or as plain text. Rendered as _Requirement Class_.
 
 * `inherit` (optional). Dependencies of the conformance class. Accepts multiple
-semicolon-delimited values, which each could be a cross-reference to another
-conformance class or plain text.
+values, which each could be a cross-reference to another
+conformance class or plain text. See <<general,Requirement, recommendation, permission>>.
 
 Conformance classes also feature:
 
 * Name (optional). Specified as the block caption.
 
-* Nesting (optional). Conformance tests contained in a conformance class are encoded as conformance tests within the conformance class block.
+* Nesting (optional). Conformance tests contained in a conformance class are encoded as conformance tests within the conformance class block. See <<reqt_class,Requirements class>>.
 
 NOTE: Conformance classes do not have a Target Type (as specified in ModSpec).
 If one must be encoded, it should be encoded as a Classification key-value
@@ -547,6 +604,19 @@ EXAMPLE:
 ====
 ----
 
+[source,asciidoc]
+----
+[requirement]
+====
+[%metadata]
+type:: conformanceclass
+label:: http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs
+subject:: <<rc_crs,Requirements Class 'Coordinate Reference Systems by Reference'>>
+inherit:: http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#ats_core
+classification:: Target Type:Web API
+====
+----
+
 renders as:
 
 ____
@@ -556,7 +626,7 @@ ____
 2+a|Conformance Class 1
 
 2+a|http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs
-|Requirements Class  |_Requirements Class 'Coordinate Reference Systems by Reference_
+|Requirements Class  |_Requirements Class 'Coordinate Reference Systems by Reference'_
 |Dependency   |http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#ats_core
 |Target Type   |Web API
 |===
@@ -589,10 +659,10 @@ base ModSpec attributes:
 plain text. Multiple semicolon-delimited values may be provided. Rendered as
 _Requirement_.
 
-* `inherit` (optional). Dependencies. Accepts multiple semicolon-delimited
-values. Each may be a cross-reference or in plain text.
+* `inherit` (optional). Dependencies. Accepts multiple values. Each may be a cross-reference or in plain text.
+See <<general,Requirement, recommendation, permission>>.
 
-* `component` (optional). Components of the conformance test. Accepts rich
+* Components (optional). Components of the conformance test. Accepts rich
 text. [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.0].
 Allows the following classes:
 
@@ -615,7 +685,7 @@ output [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v0.2.10
 
 EXAMPLE:
 
-.Example of Abstract test from CityGML 3.0
+.Example of Abstract test from CityGML 3.0 (block attributes)
 [source,adoc]
 ----
 [[ats_core_classes]]
@@ -645,7 +715,25 @@ Validate that the data element has the same relationships with other elements as
 ====
 ----
 
-.Example of Abstract test from DGGS
+.Example of Abstract test from CityGML 3.0 (definition list)
+[source,adoc]
+----
+[[ats_core_classes]]
+[requirement]
+====
+[%metadata]
+type:: abstracttest
+label:: /ats/core/classes
+subject:: <<req_core_classes,/req/core/classes>>
+test-purpose:: To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
+test-method:: Manual Inspection
+description:: For each UML class defined or referenced in the Core Package:
+part:: Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
+part:: Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicities as those documented in the Conceptual Model.
+====
+----
+
+.Example of Abstract test from DGGS (block attributes)
 [source,asciidoc]
 ----
 [requirement,type="abstracttest",label="/conf/crs/crs-uri",subject="<<req_crs_crs-uri,/req/crs/crs-uri>>,<<req_crs_fc-md-crs-list_A,/req/crs/fc-md-crs-list A>>,<<req_crs_fc-md-storageCrs,/req/crs/fc-md-storageCrs>>,<<req_crs_fc-md-crs-list-global,/req/crs/fc-md-crs-list-global>>",classification="Test Type:Basic"]
@@ -674,6 +762,36 @@ https://tools.ietf.org/html/rfc3986#section-3[RFC 3986, section 3].
 
 ====
 ----
+
+.Example of Abstract test from DGGS (definitions list)
+[source,asciidoc]
+----
+[requirement]
+====
+[%metadata]
+type:: abstracttest
+label:: /conf/crs/crs-uri
+subject:: <<req_crs_crs-uri,/req/crs/crs-uri>>
+subject:: <<req_crs_fc-md-crs-list_A,/req/crs/fc-md-crs-list A>>
+subject:: <<req_crs_fc-md-storageCrs,/req/crs/fc-md-storageCrs>>
+subject:: <<req_crs_fc-md-crs-list-global,/req/crs/fc-md-crs-list-global>>"
+classification:: Test Type:Basic
+test-purpose:: Verify that each CRS identifier is a valid value
+test-method::
++
+--
+For each string value in a `crs` or `storageCrs` property in the collections and collection objects,
+validate that the string conforms to the generic URI syntax as specified by
+https://tools.ietf.org/html/rfc3986#section-3[RFC 3986, section 3].
+
+. For http-URIs (starting with `http:`) validate that the string conforms to the syntax specified by RFC 7230, section 2.7.1.
+
+. For https-URIs (starting with `https:`) validate that the string conforms to the syntax specified by RFC 7230, section 2.7.2.
+--
+reference:: <<ogc_07_147r2,clause=15.2.2>>
+====
+----
+
 
 renders as:
 
@@ -742,16 +860,25 @@ they are semicolon delimited [added in https://github.com/metanorma/metanorma-st
 by the attribute value. If there are multiple values of the subject,
 they are semicolon delimited.
 
-** The `component` components of the
+** The `classification` attributes of the requirement, if given: the
+classification tag (in capitals), followed by the classification value.
+
+* The remaining rows of the requirement are the remaining components of the
+requirement, encoded as table rows instead of as a definition table (as they are
+by default in Metanorma).
+
+** These include the explicit `component` components of the
 requirement [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.4.0],
-which capture internal components of the requirement.
+which capture internal components of the requirement defined in ModSpec.
 +
 These are divided into two categories:
 
 *** Components with a `class` attribute other than `part` are
 extracted in order, with the class name normalised (title case), followed by the component contents.
 So a component with a `class` attribute of `conditions` will be rendered as
-_Conditions_ followed by the component contents.
+_Conditions_ followed by the component contents. In the foregoing, we have seen components defined 
+in ModSpec: `test-purpose, test-method, conditions, reference`. However the block attribute
+syntax allows open-ended component names.
 
 *** Components with the `class` attribute `part` are extracted and presented in
 order: each Part is rendered as an incrementing capital letter (_A_, _B_, _C_
@@ -759,17 +886,8 @@ and so on), followed by the component contents. Any cross-references to part com
 will automatically be labelled with the label of their parent requirement, followed by their ordinal
 letter.
 
-** The `classification` attributes of the requirement, if given: the
-classification tag (in capitals), followed by the classification value.
-The `classification` attribute is marked up as in the rest of Metanorma:
-`classification="key1=value1;key2=value2..."`, where _value_ is either a single
-string, or a comma-delimited list of values.
-
-* The remaining rows of the requirement are the remaining components of the
-requirement, encoded as table rows instead of as a definition table (as they are
-by default in Metanorma).
-
-** Components can include descriptive text.
+** Components can include descriptive text (`description`), which is interleaved with
+other components.
 
 ** Components can include open blocks marked with role attributes. That includes the
 legacy Metanorma components:

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -90,7 +90,7 @@ standardization target (an entity).
 type of conformance test suite (see https://portal.ogc.org/files/?artifact_id=34762[OGC 08-131r3], 6.4). A concrete conformance test is typically called as a "`conformance test`",
 while an abstract conformance test is called an "`abstract test`".
 
-* A "`Test suite`" is a "`is a collection of identifiable conformance classes`"
+* A "`Test suite`" is "`a collection of identifiable conformance classes`"
 (see OGC 08-131r3, 6.4)
 
 ** A "`Conformance test suite`" contains only "`Conformance classes`" of the
@@ -189,7 +189,7 @@ models.
 ====
 ----
 
-TODO: Can we mix syntaxes?
+// TODO: Can we mix syntaxes?
 
 
 === Base ModSpec model attributes
@@ -686,7 +686,7 @@ ____
 |Test Method   a|For each string value in a `crs` or `storageCrs` property in the collections and collection objects,
 validate that the string conforms to the generic URI syntax as specified by
 https://tools.ietf.org/html/rfc3986#section-3[RFC 3986, section 3].
-+
+
 . For http-URIs (starting with `http:`) validate that the string conforms to the syntax specified by RFC 7230, section 2.7.1.
 . For https-URIs (starting with `https:`) validate that the string conforms to the syntax specified by RFC 7230, section 2.7.2.
 
@@ -748,7 +748,7 @@ These are divided into two categories:
 *** Components with a `class` attribute other than `part` are
 extracted in order, with the class name normalised (title case), followed by the component contents.
 So a component with a `class` attribute of `conditions` will be rendered as
-as _Conditions_ followed by the component contents.
+_Conditions_ followed by the component contents.
 
 *** Components with the `class` attribute `part` are extracted and presented in
 order: each Part is rendered as an incrementing capital letter (_A_, _B_, _C_

--- a/author/ogc/topics/requirements.adoc
+++ b/author/ogc/topics/requirements.adoc
@@ -145,7 +145,7 @@ in the definition list syntax can be fully formatted Metanorma text.
 Attributes that can take Rich textual input, such as `part` and `conditions`, are
 components of requirements in Metanorma: these are
 encoded in the block attributes syntax using the `[.component]` role within the
-ModSpec model block, as in:
+ModSpec model block, on open blocks or example blocks, as in:
 
 [source,adoc]
 ----
@@ -154,6 +154,15 @@ ModSpec model block, as in:
 --
 Part A of the requirement.
 --
+----
+
+[source,adoc]
+----
+[[part_a_of_requirement]]
+[.component,class=part]
+====
+Part A of the requirement.
+====
 ----
 
 Conversely, in definition list syntax, not only components such as `part` and

--- a/author/topics/document-format/requirements.adoc
+++ b/author/topics/document-format/requirements.adoc
@@ -128,8 +128,9 @@ You can mark up the internal structure of a requirement to make it machine-reada
 although this is not expected to be reflected in rendering.
 
 The internal structure of requirements is marked up with open blocks,
+or [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v1.10.6] example blocks,
 which are marked up with a succession of two or more hyphens, rather than equals signs.
-Each open block needs to be named with the kind of component it contains
+Each block needs to be named with the kind of component it contains
 as a role attribute; the recognised values for Metanorma are:
 
 * specification (a formal statement, which may be considered
@@ -152,9 +153,9 @@ This is a formal specification
 --
 
 [.measurement-target]
---
+=====
 This is a measurement target
---
+=====
 
 [.verification]
 --


### PR DESCRIPTION
Hey @ronaldtse,

This PR just contains a few typos that @anermina and I found in Requirement page.
But it is also meant for applying further changes on the way as we discuss about the subject.

Like @anermina, I also think the page is readable for the OGC authors.
But as a recommendation, I would consider helpful that for every requirement encoded with block attribute approach, we also 
expose its DL syntax equivalent. Because, while I was reading the page, several questions came to my mind on how I would encode *this or that* requirement using DL syntax.

