### PR TITLE
#494 #497 split install.adoc to several pages and add CI/CD page

### DIFF
--- a/_pages/install.adoc
+++ b/_pages/install.adoc
@@ -8,32 +8,52 @@ redirect_from:
 
 = Setting up Metanorma
 
-To build documents with Metanorma, you need to have the Metanorma
-command-line toolchain installed.
+The Metanorma command-line toolchain can be installed with any of the following
+installation methods suitable for your platform.
 
-The toolchain consists of `metanorma-cli` Ruby gem and its dependencies.
+== Platform-specific installation
 
-In general, these installation methods are recommended.
+Choose your platform:
 
-Platform-specific methods:
+* link:/setup/macos/[macOS]
+* link:/setup/windows/[Windows]
+* link:/setup/linux/[Linux]
 
-* link:/setup/macos/[macOS via our Homebrew formula] 
-* link:/setup/linux/[Linux via our Snapcraft package]
-* link:/setup/windows/[Windows via our Chocolatey package]
+== Platform-independent installation
 
-Platform-independent methods:
+The following installation methods are intended for skilled Metanorma experts
+who develop on Metanorma or require automated actions.
 
 * link:/setup/docker/[Docker]
-* link:/software/metanorma-cli/[Ruby: install the native Ruby `metanorma-cli` gem]
-
++
 [TIP]
+.Installing via Docker
 ====
-.Full manual
+Docker is a platform-independent container engine. The official
+https://hub.docker.com/u/metanorma[Metanorma Docker containers on Docker Hub]
+provide a simple and consistent to run Metanorma, especially on
+continuous integration (CI) environments.
+====
 
-Assuming you know what you’re doing, you can manually install the `metanorma-cli` gem.
+* link:/software/metanorma-cli/[Ruby gem]
++
+[TIP]
+.Manual installation
+====
+Assuming you know what you’re doing, the
+https://rubygems.org/gems/metanorma-cli[metanorma-cli] gem can be manually
+installed.
+
 You will have to take care of dependencies: an appropriate Ruby version,
 plus other software depending on the end documents you’re building.
 
 Refer to link:/software/metanorma-cli/docs/installation/[Metanorma CLI installation docs]
 for details.
 ====
+
+== Continuous delivery environments
+
+Metanorma is often run on continuous integration (CI) and continuous deployment
+(CD) environments.
+
+* link:/setup/cicd[Using Metanorma with CI/CD at GitHub and GitLab]

--- a/_pages/install/cicd.adoc
+++ b/_pages/install/cicd.adoc
@@ -1,20 +1,41 @@
 ---
 layout: docs-base
 html-class: docs-page
-title: Run Metanorma in CI/CD environemnt
+title: Running Metanorma in CI/CD environments
 redirect_from:
   - /setup/cicd
 ---
+Metanorma is often run on continuous integration (CI) and continuous deployment
+(CD) environments.
 
-Because `metanorma` provides packages for different platform, which can be installed in non-interactive mode (via terminal). Check link:/install/[list of supported platfoms]
+== Running on CI/CD platforms
 
-== GitHub Actions
+We currently support the following CI/CD platforms:
 
-Also we provide several of GitHub Actions to simplify CI workflow:
+* GitHub Actions
+* GitLab CI
 
-* link:https://github.com/actions-mn/setup[`actions-mn/setup@v2`] - for installation metanorma
-* link:https://github.com/actions-mn/cli/tree/main/site-gen[`actions-mn/cli/site-gen@main`] - for site generation
 
-== GitLab CI
+=== Installation
 
-Also we have link:https://github.com/metanorma/metanorma-build-scripts/blob/master/cimas-config/gh-actions/samples/.gitlab-ci.yml[example how you can use our docker image in GitLab CI]
+Metanorma provides native packages installable on most major platforms and
+these packages can be installed through a non-interactive console/terminal.
+The full list is available link:/install/[here].
+
+Metanorma also provides additional automated actions for the setup and running
+of Metanorma on CI/CD testers.
+
+=== GitHub Actions
+
+The following GitHub Actions can be used to simplify a Metanorma CI workflow:
+
+* Installing Metanorma: link:https://github.com/actions-mn/setup[`actions-mn/setup@v2`]
+
+* Generate a Metanorma site: link:https://github.com/actions-mn/cli/tree/main/site-gen[`actions-mn/cli/site-gen@main`]
+
+=== GitLab CI
+
+For GitLab CI, Metanorma provides a sample `.gitlab-ci.yml` workflow file
+that demonstrates how to use the Metanorma docker container in the environment.
+
+* https://github.com/metanorma/metanorma-build-scripts/blob/master/cimas-config/gh-actions/samples/.gitlab-ci.yml[Sample `.gitlab-ci.yml`]

--- a/_pages/install/docker.adoc
+++ b/_pages/install/docker.adoc
@@ -1,24 +1,34 @@
 ---
 layout: docs-base
 html-class: docs-page
-title: Run Metanorma with Docker
+title: Running Metanorma with Docker
 redirect_from:
   - /setup/docker
 ---
 
+== Installing Metanorma via Docker
 
-This setup method works for all platforms that support the Docker container
-framework.
+Instead of "installing", the Metanorma Docker container makes running Metanorma
+a breeze for those that already run Docker.
+
+Docker is a platform-independent container engine that allows one to run
+packaged software easily as all dependencies are bundled within a container
+image.
 
 [TIP]
+.Possible reasons to _avoid_ running in Docker
 ====
-This method is the recommended way of getting Metanorma installed.
+* Performance. Using Metanorma inside Docker container is likely to be be
+  slower.
 
-Possible reasons to _avoid_ this method:
-
-* Performance. Using Metanorma inside Docker container may be a bit slower.
-
+* Windows. Docker on Windows require an explicit folder sharing settings in
+  order to share a local filesystem (e.g. a Metanorma document directory) to the
+  container.
 ====
+
+The steps are straightforward.
+
+== Pulling the Metanorma Docker container
 
 . Pull the container:
 +
@@ -26,42 +36,54 @@ Possible reasons to _avoid_ this method:
 ----
 docker pull metanorma/metanorma
 ----
++
 or
++
 [source,sh]
 ----
 docker pull metanorma/mn
 ----
 
-. Specify the `:local-cache-only:` AsciiDoc attribute
-in document header to speed up rendering (optional)
+== Running Metanorma using the Docker container
 
-To render the document into HTML, Word and XML,
-execute from within the directory containing the Metanorma document
-(replacing `{my-document-path}` with your actual document's filename):
+. Specify the `:local-cache-only:` Metanorma attribute in the AsciiDoc document
+header to cache bibliographic entries in the local directory (where the command
+was run) (optional).
 
+. To render a Metanorma document into its intended outputs, execute from within
+the directory containing the Metanorma document (replacing `{my-document-path}`
+with your actual document's filename):
++
 .Running the Metanorma container on macOS and Linux
 [source,console]
---
+----
 docker run -v "$(pwd)":/metanorma/ -w /metanorma metanorma/metanorma metanorma compile -t {flavor} -x {output-formats} {my-document-path}
---
-or for documents with manifest
+----
++
+or for documents with a Metanorma manifest file:
++
 [source,console]
---
+----
 docker run -v "$(pwd)":/metanorma/ -w /metanorma metanorma/metanorma metanorma site generate {my-document-dir} -o {output-directory} -c {manifest-yml} --agree-to-terms
---
-
+----
++
 .Running the Metanorma container on Windows
 [source,console]
 --
 docker run -v "%cd%":/metanorma/ -w /metanorma metanorma/metanorma metanorma compile -t {flavor} -x {output-formats} {my-document-path}
 --
 
-You can speedup compilation by caching fonts between docker runs by passing extra docker volume. Check link:/author/topics/building/font-management[how to do this]
+. You can speedup document compilation by caching fonts between docker runs by
+passing extra docker volume. More information on font caching is found on
+link:/author/topics/building/font-management[the Font Management page].
 
-Also `metanorm compile ...` is not the only one command. There are much more, check link:/software/metanorma-cli/docs/usage/[usage section]
-
+NOTE: Commands other than `metanorma compile ...` are also available on the Docker
+containers.
+See the link:/software/metanorma-cli/docs/usage/[Usage page of Metanorma CLI]
+for more details.
 
 [TIP]
 ====
-See https://github.com/metanorma/metanorma-docker[metanorma-docker] for more information.
+See the https://github.com/metanorma/metanorma-docker[metanorma-docker]
+repository for more information.
 ====

--- a/_pages/install/linux.adoc
+++ b/_pages/install/linux.adoc
@@ -1,26 +1,35 @@
 ---
 layout: docs-base
 html-class: docs-page
-title: Run Metanorma on Linux
+title: Running Metanorma on Linux
 redirect_from:
   - /setup/linux
 ---
 
-[[snap]]
-== Using https://snapcraft.io[Snap]
+== Install Metanorma via Snap
 
-The easiest way is to install the https://snapcraft.io/metanorma[Metanorma Snap]
-with a single command:
+https://snapcraft.io[Snap] is a package manager on Linux originating from
+Ubuntu that allows excellent isolation between software installs.
+
+It also happens that it is the easiest way to install Metanorma on Linux!
+
+The https://snapcraft.io/metanorma[Metanorma Snap] package can be installed with
+a single command:
 
 [source,sh]
 ----
 sudo snap install metanorma
 ----
 
-If `snapd` isn't available on your distribution, use the all-in-one install script
-described below for various platforms.
+If the Snap daemon, `snapd`, isn't available on your distribution, please
+instead use the all-in-one install script described below for various platforms.
 
-== Install script for Ubuntu
+
+== Install Metanorma via setup scripts
+
+=== Ubuntu
+
+Run the following commands.
 
 [source,sh]
 ----
@@ -28,8 +37,9 @@ sudo bash -c "curl -L https://raw.githubusercontent.com/metanorma/metanorma-linu
 curl -L https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/install-gems.sh | bash
 ----
 
+=== CentOS
 
-== Install script for CentOS
+Run the following commands.
 
 [source,sh]
 ----

--- a/_pages/install/macos.adoc
+++ b/_pages/install/macos.adoc
@@ -1,13 +1,19 @@
 ---
 layout: docs-base
 html-class: docs-page
-title: Run Metanorma on macOS
+title: Running Metanorma on macOS
 redirect_from:
   - /setup/macos
 ---
 
-[[homebrew]]
-== Using https://brew.sh/[Homebrew]
+== Install Metanorma via Homebrew
+
+https://brew.sh/[Homebrew] is a popular package manager on macOS.
+
+You will need to first install Homebrew; just run the one-line installation
+command given on https://brew.sh/[Homebrew]'s landing page.
+
+Then, run the following commands in Terminal.app:
 
 [source,sh]
 ----

--- a/_pages/install/windows.adoc
+++ b/_pages/install/windows.adoc
@@ -1,18 +1,20 @@
 ---
 layout: docs-base
 html-class: docs-page
-title: Run Metanorma on Windows
+title: Running Metanorma on Windows
 redirect_from:
   - /setup/windows
 ---
 
-[[chocolatey]]
-== Using https://chocolatey.org/[Chocolatey]
+== Install Metanorma via Chocolatey
 
-To install `chocolatey` follow https://chocolatey.org/install[these instructions]
+https://chocolatey.org/[Chocolatey] is a popular Windows package manager.
 
-Execute the following in your `cmd.exe` or `PowerShell`
-to install the Metanorma Chocolatey package:
+To install Chocolatey, please follow
+https://chocolatey.org/install[the official installation instructions].
+
+Then, run the following in your `cmd.exe` or `PowerShell` to install the
+Metanorma Chocolatey package:
 
 [source,console]
 ----
@@ -23,13 +25,12 @@ choco install metanorma -y
 ====
 For LaTeX processing, a UTF-8 compatible command line interface is necessary.
 If you are using the Windows default command line interpreter `cmd.exe`,
-please do run `chcp 65001` before using Metanorma.
+please run `chcp 65001` before using Metanorma.
 ====
 
 [TIP]
 ====
 See
 link:/blog/12-25-2018/metanorma-on-windows-via-chocolatey/[the blog post on Metanorma Chocolatey package]
-for more background.
+for more background information.
 ====
-


### PR DESCRIPTION
 - #494
 - #497

What was done:
 - install page splitter on several pages
 - CI/CD install page added
 - added internal links from docker page to font caching page
 - removed outdated dependencies