### PR TITLE
Rename Asciidoctor::X to Metanorma::X

### DIFF
--- a/author/ref/document-attributes.adoc
+++ b/author/ref/document-attributes.adoc
@@ -89,7 +89,7 @@ File containing predefined text of document, in Metanorma XML. The document
 predefined text needs to follow the structure described in
 link:/builder/topics/metadata-and-boilerplate#boilerplate[Predefined text];
 compare examples of Metanorma predefined text files such as
-https://github.com/metanorma/metanorma-itu/blob/main/lib/asciidoctor/itu/boilerplate.xml[that in ITU]
+https://github.com/metanorma/metanorma-itu/blob/main/lib/metanorma/itu/boilerplate.xml[that in ITU]
 [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v1.3.15].
 
 

--- a/builder/topics/adopting-toolchain.adoc
+++ b/builder/topics/adopting-toolchain.adoc
@@ -26,7 +26,7 @@ To customise behaviour further than Simple Adoption, you need to create a custom
 
 ** Change the root tag and namespace to a namespace specific to
   your organization's document standard
-  (`XML_ROOT_TAG` and `XML_NAMESPACE` located in `.../lib/asciidoctor/{flavour}/converter.rb`)
+  (`XML_ROOT_TAG` and `XML_NAMESPACE` located in `.../lib/metanorma/{flavour}/converter.rb`)
 
 * Change any references to `ribose` or `Ribose`
   in the gem to your organization's document standard.
@@ -46,13 +46,13 @@ The toolchains currently available proceed in two steps:
 
 Running the `metanorma` CLI tool involves a third step, of exposing the capabilities available in the first two in a consistent format.
 
-These two steps are represented as three separate modules, which are included in the same gem; for the Generic gem, they are `Asciidoctor::Generic`, `Isodoc::Generic`, and `Metanorma::Generic`.
+These two steps are represented as three separate modules, which are included in the same gem; for the Generic gem, they are `Isodoc::Generic`, and `Metanorma::Generic`.
 
 Your adaptation of the toolchain will need to instantiate these three modules. The connection between the two first steps is taken care of in the toolchain, and metanorma explicitly invokes the two steps, feeding the XML output of the first step as input into the second. The metanorma-sample gem outputs both Word and HTML; you can choose to output only Word, or only HTML, and you can choose to generate PDF as well.
 
-The modules involve classes which rely on inheritance from other classes; the current gems use `Asciidoctor::{Standoc, ISO, Generic}::Converter`, `Isodoc::{Metadata, HtmlConvert, WordConvert}`, and `Metanorma::Processor` as their base classes. This allows the standards-specific classes to be quite succinct, as most of their behaviour is inherited from other classes; but it also means that you need to be familiar with the underlying gems, in order to do most customization.
+The modules involve classes which rely on inheritance from other classes; the current gems use `Metanorma::{Standoc, ISO, Generic}::Converter`, `Isodoc::{Metadata, HtmlConvert, WordConvert}`, and `Metanorma::Processor` as their base classes. This allows the standards-specific classes to be quite succinct, as most of their behaviour is inherited from other classes; but it also means that you need to be familiar with the underlying gems, in order to do most customization.
 
-In the case of `Asciidoctor::X` classes, the changes you will need to make involve the intermediate XML representation of your document, which is built up through Nokogiri Builder; e.g. adding different enums, or adding new elements. The adaptations in `Asciidoctor::Generic::Converter` are limited (and are almost all to do with reading in properties from a config file), and most projects can take them across as is.
+In the case of `Metanorma::X` classes, the changes you will need to make involve the intermediate XML representation of your document, which is built up through Nokogiri Builder; e.g. adding different enums, or adding new elements. The adaptations in `Metanorma::Generic::Converter` are limited (and are almost all to do with reading in properties from a config file), and most projects can take them across as is.
 
 The customizations needed for `Metanorma::Sample::Processor` are minor, and involve invoking methods specific to the gem for document generation.
 
@@ -74,7 +74,7 @@ See link:/builder/topics/metadata-and-boilerplate/[Metadata and Predefined text]
 
 The `Isodoc::HtmlConvert` and `Isodoc::WordConvert` are expected to be near-identical, since any rendering differences between the two are addressed in the HTML CSS stylesheet. The `Isodoc::HtmlConvert` and `Isodoc::WordConvert` overlap substantially, as both use variants of HTML. However there is no reason not to make substantially different rendering choices in the HTML and Word branches of the code.
 
-=== Asciidoctor::Standoc customization examples
+=== Metanorma::Standoc customization examples
 
 In the following snippets, the parameter `node` represents the current node of the AsciiDoc document, and `xml` represents the Nokogiri Builder node of the XML output.
 
@@ -206,7 +206,7 @@ end
 [source,ruby]
 --
 def version
-  "Asciidoctor::Sample #{Asciidoctor::Sample::VERSION}"
+  "Metanorma::Sample #{Metanorma::Sample::VERSION}"
 end
 --
 

--- a/builder/topics/metadata-and-boilerplate.adoc
+++ b/builder/topics/metadata-and-boilerplate.adoc
@@ -19,7 +19,7 @@ These elements are populated either from the document attributes in the
 Metanorma AsciiDoc input, or with default values.
 
 Specifically, the `bibdata` element is populated through the
-`Asciidoctor::Standoc::Converter.metadata` method, and its inheritors.
+`Metanorma::Standoc::Converter.metadata` method, and its inheritors.
 
 The `bibdata` element is not rendered directly as the document front
 page. Instead, the document front page, and other  templated texts, are
@@ -383,7 +383,7 @@ status to turn line numbering on or off in the Word stylesheet.
 (Draft documents are line-numbered, and whether a document is in draft
 or not depends on the value of `bibdata/status`.)
 
-* Under the `asciidoctor/*` directory of the gem:
+* Under the `metanorma/*` directory of the gem:
 
 ** The Metanorma predefined text file (`boilerplate.xml`)
 

--- a/builder/topics/simple-adoption.adoc
+++ b/builder/topics/simple-adoption.adoc
@@ -55,7 +55,7 @@ document_namespace: https://www.metanorma.org/standards/generic
 xml_root_tag: 'generic-standard'
 logo_path: lib/isodoc/generic/html/logo.jpg
 logo_paths: []
-validate_rng_file: lib/asciidoctor/generic/generic.rng
+validate_rng_file: lib/metanorma/generic/generic.rng
 htmlcoverpage: lib/isodoc/generic/html/html_generic_titlepage.html
 htmlintropage: lib/isodoc/generic/html/html_generic_intro.html
 htmlstylesheet: lib/isodoc/generic/html/htmlstyle.scss
@@ -66,7 +66,7 @@ wordcoverpage: lib/isodoc/generic/html/word_generic_titlepage.html
 wordintropage: lib/isodoc/generic/html/word_generic_intro.html
 wordstylesheet: lib/isodoc/generic/html/wordstyle.scss
 i18nyaml: lib/isodoc/generic/html/i18n-en.yml
-boilerplate: lib/asciidoctor/generic/boilerplate.xml
+boilerplate: lib/metanorma/generic/boilerplate.xml
 docid_template: "{{ organization_name_short }} {{ docnumeric }}"
 published_stages: ["published", "withdrawn"]
 committees: []
@@ -128,7 +128,7 @@ For example, `metanorma -t {short name} document.adoc` or `:mn-document-class: {
 ----
 --
 
-`validate_rng_file`:: validation file with rules used in your flavour, see https://github.com/metanorma/metanorma-generic/blob/main/lib/asciidoctor/generic/generic.rng for example. This and all other file directory paths are relative to the gem root.
+`validate_rng_file`:: validation file with rules used in your flavour, see https://github.com/metanorma/metanorma-generic/blob/main/lib/metanorma/generic/generic.rng for example. This and all other file directory paths are relative to the gem root.
 
 `htmlcoverpage`/`htmlintropage`/`htmlstylesheet`/`scripts`::
 paths used for styling HTML output files.
@@ -391,7 +391,7 @@ Metanorma::Generic.configure do |config|
   config.logo_path = File.join(isodoc_rsd_html_folder, 'logo.png')
   config.xml_root_tag = 'ribose-standard'
 
-  rsd_rng_folder = File.join(File.expand_path('asciidoctor', __dir__), 'ribose')
+  rsd_rng_folder = File.join(File.expand_path('metanorma', __dir__), 'ribose')
   config.validate_rng_file = File.join(rsd_rng_folder, 'ribose.rng')
 end
 
@@ -399,7 +399,7 @@ require 'metanorma/ribose'
 require 'isodoc/generic'
 
 require 'asciidoctor' unless defined? Asciidoctor::Converter
-require 'asciidoctor/ribose'
+require 'metanorma/ribose'
 --
 
 In this configuration, you have to provide paths to your style definitions:
@@ -415,40 +415,39 @@ In this step you will create these folders:
 
 * `lib/metanorma/{your-flavor-name}/`
 * `lib/isodoc/{your-flavor-name}/`
-* `lib/asciidoctor/{your-flavor-name}/`
 
 And these files:
 
 * `lib/metanorma/{your-flavor-name}.rb`
 * `lib/metanorma/{your-flavor-name}/processor.rb`
 * `lib/metanorma/{your-flavor-name}/version.rb`
+* `lib/metanorma/{your-flavor-name}/converter.rb`
 * `lib/isodoc/{your-flavor-name}.rb`
 * `lib/isodoc/{your-flavor-name}/metadata.rb`
 * `lib/isodoc/{your-flavor-name}/{converter-type}.rb` (one converter per output format)
-* `lib/asciidoctor/{your-flavor-name}.rb`
-* `lib/asciidoctor/{your-flavor-name}/converter.rb`
 
 For example, in `metanorma-ribose`, you would have these files:
 
 * `lib/metanorma/ribose.rb`
 * `lib/metanorma/ribose/processor.rb`
 * `lib/metanorma/ribose/version.rb`
+* `lib/metanorma/ribose/converter.rb`
 * `lib/isodoc/ribose.rb`
 * `lib/isodoc/ribose/metadata.rb`
 * `lib/isodoc/ribose/html_converter.rb`
 * `lib/isodoc/ribose/word_converter.rb`
-* `lib/asciidoctor/ribose.rb`
-* `lib/asciidoctor/ribose/converter.rb`
 
 
 The first file `lib/metanorma/{your-flavor-name}.rb` defines your module,
-and links your flavor's processor to the Metanorma processor framework.
+and links your flavor's processor to the Metanorma processor framework, and
+also your input converters.
 
 [source,ruby]
 --
 # lib/metanorma/ribose.rb
 require "metanorma"
 require "metanorma/ribose/processor"
+require "metanorma/ribose/converter"
 
 module Metanorma
   module Rsd
@@ -578,38 +577,21 @@ end
 --
 
 
-Create `lib/asciidoctor/{your-flavor-name}.rb` to house your
-input converters.
-
-[source,ruby]
---
-# lib/asciidoctor/ribose.rb
-require "metanorma/ribose/version"
-require_relative "ribose/converter"
-
-module Asciidoctor
-  module Rsd
-
-  end
-end
---
-
-
-`lib/asciidoctor/{your-flavor-name}/converter.rb`
+`lib/metanorma/{your-flavor-name}/converter.rb`
 registers your new flavour to be used in `Metanorma::Cli`.
 
 [source,ruby]
 --
-# lib/asciidoctor/ribose/converter.rb
-require "asciidoctor/standoc/converter"
-require 'asciidoctor/generic/converter'
+# lib/metanorma/ribose/converter.rb
+require "metanorma/standoc/converter"
+require 'metanorma/generic/converter'
 
-module Asciidoctor
+module Metanorma
   module Rsd
     # A {Converter} implementation that generates Ribose output, and a document
     # schema encapsulation of the document for validation
     #
-    class Converter < Asciidoctor::Generic::Converter
+    class Converter < Metanorma::Generic::Converter
       register_for "ribose"
     end
   end


### PR DESCRIPTION
Please refer to: https://github.com/metanorma/metanorma-standoc/issues/586

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
