### PR TITLE
adoc updated, 'from' and 'to' escaped

### DIFF
--- a/_posts/2022-08-22-annotations-available-in-all-ouputs.adoc
+++ b/_posts/2022-08-22-annotations-available-in-all-ouputs.adoc
@@ -249,7 +249,7 @@ The ranged reviewer note renders as following:
 ==== Example
 
 The following example applies a reviewer note that highlights a textual range,
-namely, the text wrapped by the `[[start_review1]]` and `[[end_review1]]`
+namely, the text wrapped by the `{{{[[start_review1]]}}}` and `{{{[[end_review1]]}}}`
 anchors. The reviewer note specifies `from=start_review1,to=end_review1`
 as the start and end.
 


### PR DESCRIPTION
### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
