### PR TITLE
fix: ISO normative reference is always at Clause 3

### DIFF
--- a/author/cc/authoring.adoc
+++ b/author/cc/authoring.adoc
@@ -61,7 +61,7 @@ other committees are added as `_3`, `_4`...
 [[note_general_doc_ref_terms_defs_calconnect]]
 NOTE: This section supplements link:/author/topics/document-format/section-terms[The “Terms and Definitions” section] in general Metanorma documentation.
 
-This must be clause 3.
+This must be Clause 3.
 
 [source,adoc]
 ----

--- a/author/topics/document-format/bibliography.adoc
+++ b/author/topics/document-format/bibliography.adoc
@@ -26,14 +26,14 @@ Every bibliographic section must be preceded by the style attribute
 .Example of creating the "`Normative references`" clause in an ISO deliverable
 ====
 In ISO, the "`Normative references`" clause is stated in
-Clause 3 (ISO Directives Part 2, Clause 15), while the "`Bibliography`"
+Clause 2 (ISO Directives Part 2, Clause 15), while the "`Bibliography`"
 section is set as the last unnumbered section at the end of document
 (ISO Directives Part 2, Clause 21). It should be typeset as the following:
 
 [source,asciidoc]
 ----
 ...
-// This is Clause 3 of an ISO deliverable
+// This is Clause 2 of an ISO deliverable
 [bibliography]
 == Normative references
 
@@ -42,7 +42,7 @@ section is set as the last unnumbered section at the end of document
 
 ...
 
-// This is the last clause of an ISO deliverable
+// This is after the last clause of an ISO deliverable
 [bibliography]
 == Bibliography
 


### PR DESCRIPTION
Fixes #675