### PR TITLE
Document `noheader` option to prevent repetition of table header

### DIFF
--- a/author/topics/document-format/text.adoc
+++ b/author/topics/document-format/text.adoc
@@ -944,11 +944,11 @@ The following syntax will be processed as generating equal width columns.
 NOTE: In typical AsciiDoc, `[cols="3"]` is considered a shorthand to
 `[cols="1,1,1"]`, but this is not supported in Metanorma AsciiDoc.
 
-For long tables that need to continue on the next page in DOC/PDF version,
+For long tables that need to continue onto the next page in the DOC or PDF rendering of a document,
 Metanorma, by default, will automatically repeat the header after every page break.
 To suppress this behavior, you can apply the `noheader` value to the `options` attribute
-in its formal (`options=noheader`) or shorthand (`%noheader`) syntax.
-With the caveat that this option will also deactivate the implicit assignment of the
+using its formal (`options=noheader`) or shorthand (`%noheader`) syntax.
+There is a caveat that this option will also deactivate the implicit assignment of the
 header to the first row of the table
 (see link:https://docs.asciidoctor.org/asciidoc/latest/tables/add-header-row/#implicitly-assign-header-to-the-first-row[Implicitly assign header to the first row]).
 Therefore, you will need to apply the header tag (`h|`) to every cell of the first

--- a/author/topics/document-format/text.adoc
+++ b/author/topics/document-format/text.adoc
@@ -944,6 +944,15 @@ The following syntax will be processed as generating equal width columns.
 NOTE: In typical AsciiDoc, `[cols="3"]` is considered a shorthand to
 `[cols="1,1,1"]`, but this is not supported in Metanorma AsciiDoc.
 
+For long tables that need to continue on the next page in DOC/PDF version,
+Metanorma, by default, will automatically repeat the header after every page break.
+To suppress this behavior, you can apply the `noheader` value to the `options` attribute
+in its formal (`options=noheader`) or shorthand (`%noheader`) syntax.
+With the caveat that this option will also deactivate the implicit assignment of the
+header to the first row of the table
+(see link:https://docs.asciidoctor.org/asciidoc/latest/tables/add-header-row/#implicitly-assign-header-to-the-first-row[Implicitly assign header to the first row]).
+Therefore, you will need to apply the header tag (`h|`) to every cell of the first
+row to define it as the header.
 
 == Mathematical expressions
 


### PR DESCRIPTION
Fixes https://github.com/metanorma/metanorma.org/issues/665