### PR TITLE
Fix broken links on the website

### DIFF
--- a/author/basics/entering-bib.adoc
+++ b/author/basics/entering-bib.adoc
@@ -42,7 +42,7 @@ To cite an entry from your bibliography:app-name:
 
 . Enter the anchor name like this: `\<<ISO20483>>`.
 . To specify a location within the cited document, you can add
-link:/author/topics/document-format/xrefs/#localities[localities] in the
+link:/author/topics/inline_markup/citations/#localities[localities] in the
 brackets like so: `\<<ISO20483, part=IV,chapter=3,paragraph=12>>`.
 
 == Bibliography example

--- a/author/basics/xrefs.adoc
+++ b/author/basics/xrefs.adoc
@@ -35,7 +35,7 @@ converted into XML, and therefore *must not* contain the following:
 These cases are not supported in XML; permitted characters are specified by the link:https://www.w3.org/TR/xml-names11/#NT-NCName[NCName attribute for Namesapece Declaration].
 
 Colons in cross-references are used for
-link:/author/topics/document-format/collections/cross-referencing#indirect-xrefs[indirect cross-references between files in the same collection],
+link:/author/topics/collections/cross-referencing#indirect-xrefs[indirect cross-references between files in the same collection],
 to delimit namespaces and containers from anchor IDs [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v1.7.4].
 
 == Unambiguous referencing

--- a/author/cc/authoring.adoc
+++ b/author/cc/authoring.adoc
@@ -59,7 +59,7 @@ other committees are added as `_3`, `_4`...
 === Terms and Definitions
 
 [[note_general_doc_ref_terms_defs_calconnect]]
-NOTE: This section supplements link:/author/topics/document-format/section-terms[The "Terms and Definitions" section] in general Metanorma documentation.
+NOTE: This section supplements link:/author/topics/sections/concepts/[The "Concepts, designations, terms and definitions" section] in general Metanorma documentation.
 
 This must be Clause 3.
 

--- a/author/ietf/topics/references-v2.adoc
+++ b/author/ietf/topics/references-v2.adoc
@@ -12,7 +12,7 @@ version uses native Metanorma representation of references, as auto-fetched via 
 or notated as Relaton definition lists.
 
 [[note_general_doc_ref_bib-ietf]]
-NOTE: This section supplements link:/author/topics/document-format/bibliography[References & Bibliography] in general Metanorma documentation.
+NOTE: This section supplements link:/author/topics/sections/bibliography/[References & Bibliography] in general Metanorma documentation.
 
 == Embedded in Document
 

--- a/author/ietf/topics/references.adoc
+++ b/author/ietf/topics/references.adoc
@@ -12,7 +12,7 @@ version used in previous versions; in particular, the processing of references i
 with that in the rest of Metanorma.
 
 [[note_general_doc_ref_bib-ietf]]
-NOTE: This section supplements link:/author/topics/document-format/bibliography[References & Bibliography] in general Metanorma documentation.
+NOTE: This section supplements link:/author/topics/sections/bibliography/[References & Bibliography] in general Metanorma documentation.
 
 == Embedded in Document
 

--- a/author/iso/topics/markup.adoc
+++ b/author/iso/topics/markup.adoc
@@ -305,7 +305,7 @@ _ISO 7301, 3.1_.
 == Terms and definitions
 
 NOTE: This subsection supplements
-link:/author/topics/document-format/section-terms[Terms and definitions] in
+link:/author/topics/sections/concepts/[Concepts, designations, terms and definitions] in
 general Metanorma documentation.
 
 === Terminological entry numbering
@@ -512,7 +512,7 @@ _terminological data_ (3.1.3) related to one _concept_ (3.2.1)
 ____
 
 This is done in Metanorma by using citation of terms, on which see
-link:/author/topics/document-format/section-terms#citeterms[Referencing concepts] [added in https://github.com/metanorma/metanorma-iso/releases/tag/v1.8.6].
+link:/author/topics/sections/concepts/#citeterms[Referencing concepts] [added in https://github.com/metanorma/metanorma-iso/releases/tag/v1.8.6].
 
 So the foregoing instance would be automatically generated through:
 
@@ -734,7 +734,7 @@ ISO/IEC DIR 2:
 == Bibliographies
 
 [[note_general_doc_ref_bib]]
-NOTE: This subsection supplements link:/author/topics/document-format/bibliography[References and bibliography] in general Metanorma documentation.
+NOTE: This subsection supplements link:/author/topics/sections/bibliography/[References and bibliography] in general Metanorma documentation.
 
 All references under "Normative references" are expected to have a standard
 document identifier.
@@ -854,7 +854,7 @@ Clauses are only expected to be one level deep.
 
 The clauses in amendments and technical corrigenda are instances of the
 change clauses described in
-link:/author/topics/document-format/changes[Machine-readable changes].
+link:/author/topics/inline_markup/changes/[Machine-readable changes].
 
 [source,adoc]
 ----

--- a/author/ogc/authoring-guide/block-syntax.adoc
+++ b/author/ogc/authoring-guide/block-syntax.adoc
@@ -313,4 +313,4 @@ include::author/ogc/topics/markup.adoc[tag=unnumbered-ogc]
 
 == ModSpec requirements
 
-For guidance on how to specify ModSpec requirements in Metanorma, see link:/author/topics/document-format/requirements-modspec[ModSpec recommendations, requirements, and permissions].
+For guidance on how to specify ModSpec requirements in Metanorma, see link:/author/topics/blocks/requirements-modspec/[ModSpec recommendations, requirements, and permissions].

--- a/author/ogc/authoring.adoc
+++ b/author/ogc/authoring.adoc
@@ -451,7 +451,7 @@ In this clause we will use the term "`requirement`" to refer to the
 generic class of recommendations, requirements and permissions.
 
 NOTE: This subsection supplements
-link:/author/topics/document-format/requirements[Requirement, Recommendation, and Permission blocks]
+link:/author/topics/blocks/requirements/[Requirements and provisions]
 in general Metanorma documentation.
 
 ==== Requirement verifications (tests)

--- a/author/ogc/topics/markup.adoc
+++ b/author/ogc/topics/markup.adoc
@@ -64,7 +64,7 @@ clauses.
 // end::term-def-ogc[]
 
 NOTE: This section supplements
-link:/author/topics/document-format/section-terms[Terms and definitions] in
+link:/author/topics/sections/concepts/[Concepts, designations, terms and definitions] in
 general Metanorma documentation.
 
 // tag::term-def-ogc[]
@@ -199,7 +199,7 @@ A default OGC introductory text is inserted at the beginning of the clause in
 accordance to OGC policies.
 
 As described in
-link:/author/topics/document-format/section-terms/[generic terms and definitions]
+link:/author/topics/sections/concepts/[generic terms and definitions]
 documentation, this text can be overridden by using the `[.boilerplate]`
 attribute applied to the first subclause.
 

--- a/author/ref/asciidoc-tips.adoc
+++ b/author/ref/asciidoc-tips.adoc
@@ -21,7 +21,7 @@ This is due to a stylistic bias against digressive text by the
 Asciidoctor project, and probably will not change.
 
 Metanorma introduces a footnote macro `footnoteblock:[id]` which allows multi-paragraph
-notes to be treated as footnotes: see link:/author/topics/document-format/text/#footnotes[Footnotes].
+notes to be treated as footnotes: see link:/author/topics/inline_markup/footnotes/[Footnotes].
 
 == Complex notes and admonitions
 

--- a/author/ref/document-attributes.adoc
+++ b/author/ref/document-attributes.adoc
@@ -86,7 +86,7 @@ the STEM expressions in your document to be interpreted as LaTeX by default,
 use `:stem: latexmath`.
 
 Read more about
-link:/author/topics/document-format/text/#mathematical-expressions[mathematical expressions].
+link:/author/topics/blocks/math/[mathematical expressions].
 
 `:number-presentation:`::
 Sets the formatting options for the `number:[]` command in the document.
@@ -882,7 +882,7 @@ attribute value provides a prefix that will be removed from all ModSpec instance
 identifiers used to cross-reference ModSpec instances. The specification of the
 pattern only affects the rendering of cross-references, not the underlying XML
 representation of the ModSpec instances. See more details at
-link:/author/topics/document-format/requirements-modspec/#identifier-base[ModSpec identifier base]. [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v2.2.7].
+link:/author/topics/blocks/requirements-modspec/#identifier-base[ModSpec identifier base] [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v2.2.7].
 
 `:block-unnumbered:`::
 (optional)

--- a/author/topics/blocks/requirements-mrr.adoc
+++ b/author/topics/blocks/requirements-mrr.adoc
@@ -72,7 +72,7 @@ Components may be targeted towards human- or machine-readability.
 ==== Instance syntax
 
 The method of encoding an MRR model follows the general syntax described in
-link:/author/topics/document-format/requirements[requirements].
+link:/author/topics/blocks/requirements/[requirements].
 
 The encoding syntax is as follows, where the block definition describes the
 type of the model.

--- a/author/topics/blocks/requirements.adoc
+++ b/author/topics/blocks/requirements.adoc
@@ -67,9 +67,9 @@ instances to have identifiers being unique URIs.
 Metanorma allows requirements to be specified in the following
 model schemes [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v2.2.1].
 
-* link:/author/topics/document-format/requirements-mrr[Metanorma MMR: `mrr` or `default`]
+* link:/author/topics/blocks/requirements-mrr/[Metanorma MMR: `mrr` or `default`]
 
-* link:/author/topics/document-format/requirements-modspec[OGC ModSpec: `ogc`]
+* link:/author/topics/blocks/requirements-modspec/[OGC ModSpec: `ogc`]
 
 * ISO/TC 211 requirements (TBD)
 

--- a/author/topics/collections/cross-referencing.adoc
+++ b/author/topics/collections/cross-referencing.adoc
@@ -13,7 +13,7 @@ specific location within the target document.
 
 Documents are processed one document at a time; so such a link is encoded as a
 bibliographical reference, to an external document, as described in
-link:/author/topics/document-format/bibliography[Bibliography].
+link:/author/topics/sections/bibliography/[Bibliography].
 
 This means that an author needs to define a bibliographic entry for each
 hyperlinked document in the same collection; those bibliographic entries will be

--- a/author/topics/document-format/xrefs.adoc
+++ b/author/topics/document-format/xrefs.adoc
@@ -307,7 +307,7 @@ These cases are not supported in XML; permitted characters are specified by the
 link:https://www.w3.org/TR/xml-names11/#NT-NCName[NCName attribute for Namespace Declaration].
 
 Colons in cross-references are used for
-link:/author/topics/document-format/collections/cross-referencing/#indirect-xrefs[indirect cross-references between files in the same collection],
+link:/author/topics/collections/cross-referencing/#indirect-xrefs[indirect cross-references between files in the same collection],
 to delimit namespaces and containers from anchor IDs [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v1.7.4].
 
 If an anchor is not assigned to an entity, Metanorma by default assigns a GUID
@@ -331,7 +331,7 @@ both prevent URIs from being used themselves as document anchors.
 
 In order to specify the aliases of anchors manually, you will need to specify a table
 with anchor `_misccontainer_anchor_aliases` under the
-(link:/author/topics/document-format/section#misc-container[`Metanorma-Extension` clause]) [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v2.2.7].
+(link:/author/topics/sections/misc-container/[`Metanorma-Extension` clause]) [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v2.2.7].
 Each row of that table will have the anchor as its first cell, and aliases of the anchor as the other
 cells; there can be more than one alias of an anchor.
 
@@ -371,7 +371,7 @@ NOTE: This differs from the normal AsciiDoc treatment of custom text.
 --
 ====
 
-See link:/author/topics/document-format/xrefs/#localities[localities and locality values].
+See link:/author/topics/inline_markup/citations#localities[localities and locality values].
 
 == List items
 
@@ -430,7 +430,7 @@ http://www.example2.com[text to go into the hyperlink,style=brackets]
 
 == External references
 
-In link:/author/topics/document-format/xrefs/#localities[localities and locality values],
+In link:/author/topics/inline_markup/citations#localities[localities and locality values],
 anchor can be integrated in citations of documents via references.
 
 [example]

--- a/author/topics/inline_markup/changes.adoc
+++ b/author/topics/inline_markup/changes.adoc
@@ -27,7 +27,7 @@ The following attributes can be expressed on changes:
 * `locality` gives the location in the reference document to be
   modified, as a collection of locality key/values, following
   the convention in
-  link:/author/topics/document-format/xrefs/#localities[localities and locality values].
+  link:/author/topics/inline_markup/citations#localities[localities and locality values].
 
 * `path` gives an XPath within the identified locality, indicating
   the specific element to be changed.  * `path_end` is used in
@@ -141,4 +141,4 @@ del:[The use of echo cancellers on the VBD channel, as per Rec. ITU-T G.168.]
 --
 
 For more complicated corrigenda involving changes, you may
-use link:/author/topics/document-format/annotation#reviewer[reviewer notes].
+use link:/author/topics/blocks/annotations#reviewer[reviewer notes].

--- a/author/topics/inline_markup/semantic-elements.adoc
+++ b/author/topics/inline_markup/semantic-elements.adoc
@@ -130,7 +130,7 @@ date[2012-02-02T21:04:05, %F%_%l%_%p]
 
 Numbers are formatted consistent according to the current flavor, when encoded
 explicitly as such, or as encoded in
-link:/author/topics/document-format/blocks/math[mathematical expressions],
+link:/author/topics/blocks/math/[mathematical expressions],
 
 Numbers are formatted according to the flavour's specifications, where defined:
 

--- a/author/topics/inline_markup/text_formatting.adoc
+++ b/author/topics/inline_markup/text_formatting.adoc
@@ -217,7 +217,7 @@ giving a comma-delimited list of charset-font pairs.  For instance:
 :fonts: "Code 2000","BabelStone PUA"
 ----
 
-As with link:/author/topics/document-format/text#css[CSS declarations],
+As with link:/author/topics/inline_markup/text_formatting#css[CSS declarations],
 any font specified as a custom charset font also needs to be passed to Metanorma
 in the `:fonts:` document attribute.
 

--- a/author/topics/sections/attributes.adoc
+++ b/author/topics/sections/attributes.adoc
@@ -84,7 +84,7 @@ downstream.
 == Numbering
 
 As with
-link:/author/topics/document-format/text#numbering-override[block element numbering],
+link:/author/basics/numbering#numbering-override[block element numbering],
 a clause number may be provided manually to override auto-numbering.
 
 For instance, in order to number out-of-sequence clauses in updated

--- a/author/topics/sections/bibliography.adoc
+++ b/author/topics/sections/bibliography.adoc
@@ -282,7 +282,7 @@ cross-referencing within the current document. This string is typically composed
 with ASCII characters and hyphens or underscores. Other characters are not
 recommended. +
 +
-WARNING: See link:/author/topics/document-format/text#text-ref-allowed-anchors[Anchor ID syntax]
+WARNING: See link:/author/topics/document-format/xrefs#text-ref-allowed-anchors[Anchor ID syntax]
 for allowed characters in anchor IDs.
 
 document identifier:: the authoritative document identifier of the bibliographic item.
@@ -719,7 +719,7 @@ Metanorma allows bibliographic entries to be specified for retrieval from a
 Metanorma
 collection [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v1.4.1].
 
-Details on author/topics/document-format/collections#collection-cross-references
+Details on link:/author/topics/collections/cross-referencing[Collections cross-referencing].
 This is achieved with the following syntax:
 
 [source,asciidoc]

--- a/author/topics/sections/concepts.adoc
+++ b/author/topics/sections/concepts.adoc
@@ -2102,7 +2102,7 @@ default, only the display text is rendered.
 
 To supplement the concept reference with a locality, the `bibliographic-anchor`
 element can be supplemented by a comma-delimited list of
-link:/author/topics/document-format/xrefs/#localities[localities and locality values],
+link:/author/topics/inline_markup/citations/#localities[localities and locality values],
 as is normal for a reference to a locality in an external document.
 
 [source,adoc]


### PR DESCRIPTION
Closes #792 .

There are two links I am not sure about and that weren't replaced:

1. link:/author/topics/document-format/meta-attributes#doc-history-misc-container
Is the new link https://www.metanorma.org/author/ref/document-attributes#generic-metadata?

Context:
````
=== Document history

Semantic markup of document history can be added to the document,
link:/author/topics/document-format/meta-attributes#doc-history-misc-container[using Metanorma extension]
and Relaton YAML [added in https://github.com/metanorma/metanorma-ogc/releases/tag/v1.2.0].
````

2. link:/author/topics/document-format/sections#user-css
It should be https://www.metanorma.org/author/topics/inline_markup/text_formatting#css?
