### PR TITLE
Fix example in MRR documentation

### DIFF
--- a/author/topics/blocks/requirements-mrr.adoc
+++ b/author/topics/blocks/requirements-mrr.adoc
@@ -260,7 +260,7 @@ The specification component is identified by the `specification` type.
 [requirement]
 ====
 
-[statement]
+[specification]
 --
 An identifier shall be unique.
 --

--- a/author/topics/blocks/requirements.adoc
+++ b/author/topics/blocks/requirements.adoc
@@ -67,7 +67,7 @@ instances to have identifiers being unique URIs.
 Metanorma allows requirements to be specified in the following
 model schemes [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v2.2.1].
 
-* link:/author/topics/blocks/requirements-mrr/[Metanorma MMR: `mrr` or `default`]
+* link:/author/topics/blocks/requirements-mrr/[Metanorma MRR: `mrr` or `default`]
 
 * link:/author/topics/blocks/requirements-modspec/[OGC ModSpec: `ogc`]
 
@@ -87,7 +87,7 @@ standard can be very confusing to users, and therefore strongly discouraged.
 
 === Specifying model schemes
 
-For most flavors, the Metanorma MMR requirements model scheme is used by
+For most flavors, the Metanorma MRR requirements model scheme is used by
 default.
 
 For Metanorma OGC, the OGC ModSpec requirements model scheme is used by default.


### PR DESCRIPTION
As mentioned in https://github.com/metanorma/mn-samples-plateau/pull/126#issuecomment-2272739414, "statement" has been replaced with "specification" in the example from MRR documentation.

The abbreviation for machine-readable requirements has been fixed.