### PR TITLE
feat: add channel-based publication pipeline documentation

### DIFF
--- a/_pages/install/cicd.adoc
+++ b/_pages/install/cicd.adoc
@@ -82,8 +82,337 @@ https://github.com/actions-mn/build-and-publish[`actions-mn/build-and-publish`]:
 Generates a Metanorma site (using the default filename `metanorma.yml`) and
 uploads artifacts for deployment.
 
+https://github.com/actions-mn/release[`actions-mn/release`]::
+Publishes compiled Metanorma documents as per-document GitHub Releases with
+channel-based routing. Use this when you want to publish individual documents
+as downloadable releases rather than a flat site.
++
+See <<publication-pipeline>> for the full publication architecture.
+
+https://github.com/actions-mn/aggregate[`actions-mn/aggregate`]::
+Aggregates released Metanorma documents from multiple GitHub repositories with
+channel-based filtering. Use this in portal repos to collect documents from
+many source repos and build a unified document site.
++
+See <<publication-pipeline>> for the full publication architecture.
+
 For complete workflow examples, please refer to the documentation of the
 https://github.com/actions-mn/build-and-publish[`actions-mn/build-and-publish` action].
+
+
+[[publication-pipeline]]
+== Publication pipeline (per-document releases)
+
+The `actions-mn/release` and `actions-mn/aggregate` actions implement a
+channel-based publication architecture for organizations that publish many
+documents across many repositories.
+
+=== When to use this
+
+Use the release + aggregate pipeline when you have:
+
+- Multiple document repositories that each produce one or more documents
+- A portal site that aggregates documents from all repositories
+- Different document types (standards, reports, directives) that should appear
+  on different portals or in different sections
+- A need to ensure that internal or draft documents never appear on public portals
+
+For single-document sites, `actions-mn/build-and-publish` is simpler and
+sufficient.
+
+=== Architecture
+
+The publication pipeline has three stages:
+
+```
+Author          Per-document repo       GitHub            Portal repo
+sources/        .github/workflows       Releases          .github/workflows
+*.adoc    →     site-gen + release  →   per-document  →   aggregate      →  site
+                                          releases          + index.json
+```
+
+[width="100%",cols="2,3,2"]
+|===
+| Component | Role | Where
+
+| `metanorma site generate`
+| Compiles AsciiDoc sources to HTML/PDF/XML/RXL
+| Per-document repo (CI)
+
+| `actions-mn/release`
+| Discovers compiled documents, detects changes, publishes per-document GitHub Releases
+| Per-document repo (CI)
+
+| GitHub Releases
+| Stores release artifacts (zip) + metadata (channels, stage, edition)
+| GitHub
+
+| `actions-mn/aggregate`
+| Discovers repos by topic, filters by channel, downloads and indexes released documents
+| Portal repo (CI)
+|===
+
+=== Channels
+
+A channel is an `audience/category` pair that determines where a document appears:
+
+- **audience**: `public`, `members`, or `internal` — who can see it
+- **category**: free-form identifier — where it appears in the portal
+
+```
+public/standards        ← published standards, visible to everyone
+public/reports          ← conference and technical reports
+members/internal-review ← only visible to organization members
+internal/working-draft  ← never aggregated by any external portal
+```
+
+The publisher sets the channel. The aggregator filters by it. A portal *cannot*
+override or discover channels the publisher didn't assign.
+
+=== Per-document repo setup
+
+==== Release manifest (`metanorma.release.yml`)
+
+The release manifest maps documents to channels using patterns:
+
+[source,yaml]
+----
+# metanorma.release.yml
+documents:
+  - pattern: "cc-s-*"
+    channels: [public/standards]
+  - pattern: "cc-r-*"
+    channels: [public/reports]
+  - pattern: "cc-a-*"
+    channels: [public/admin]
+----
+
+When an author adds a new document whose ID matches a pattern (e.g. `cc-s-51020`),
+it is automatically assigned to the corresponding channel. No manifest update needed.
+
+For single-document repos or exceptions, use `source` instead:
+
+[source,yaml]
+----
+documents:
+  - source: sources/cc-10001.adoc
+    channels: [public/directives]
+----
+
+Stage gating prevents drafts from being published:
+
+[source,yaml]
+----
+documents:
+  - pattern: "cc-s-*"
+    stages: [published]        # only published stage creates a release
+    channels: [public/standards]
+----
+
+==== Channel discovery manifest (`.metanorma/channels.yml`)
+
+This file declares which channels a repository publishes, enabling aggregators
+to skip repos that don't match the requested channels:
+
+[source,yaml]
+----
+# .metanorma/channels.yml
+channels:
+  - name: public/standards
+    description: "Published CalConnect standards from this repo"
+----
+
+==== Release workflow
+
+[source,yml]
+----
+# .github/workflows/release.yml
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: actions-mn/.github/.github/workflows/metanorma-release.yml@main
+    with:
+      default-visibility: public    # documents not in manifest default to public
+    secrets: inherit
+----
+
+This reusable workflow runs `metanorma site generate` to compile documents,
+then `actions-mn/release` to publish changed documents as GitHub Releases.
+
+=== Portal repo setup
+
+The portal uses `actions-mn/aggregate` to discover repos, download released
+documents, filter by channel, and generate a structured index.
+
+[source,yml]
+----
+# .github/workflows/build_deploy.yml
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'    # daily refresh
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: .cache/aggregate
+          key: mn-aggregate-${{ github.run_id }}
+          restore-keys: mn-aggregate-
+
+      - name: Aggregate released documents
+        uses: actions-mn/aggregate@v1
+        id: aggregate
+        with:
+          organizations: MyOrg
+          topic: metanorma-release
+          output-dir: _site/documents
+          channels: 'public/standards,public/reports'
+          canonicalize: true
+          cache-dir: .cache/aggregate
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - uses: actions/upload-pages-artifact@v3
+----
+
+==== Aggregate action inputs
+
+[width="100%",cols="2,1,3"]
+|===
+| Input | Default | Description
+
+| `organizations` | `''` | Comma-separated GitHub organizations to scan for repos
+| `topic` | `metanorma-release` | Repository topic for auto-discovery
+| `repos` | `''` | Explicit repo list (`owner/repo`), skips topic discovery
+| `channels` | `''` | Comma-separated channels to include. Empty = all.
+| `stages` | `''` | Comma-separated stages to include. Empty = all.
+| `output-dir` | `_site/documents` | Directory for extracted document files
+| `canonicalize` | `true` | Strip edition suffixes from filenames
+| `concurrency` | `4` | Max parallel repo processing
+| `cache-dir` | `''` | Directory for persistent cache (ETags, delta state)
+| `token` | `${{ github.token }}` | GitHub token for API access
+|===
+
+=== Release metadata protocol
+
+Each GitHub Release published by `actions-mn/release` carries structured metadata:
+
+```
+content-hash:abc123...
+
+<!-- mn-release-metadata
+{"version":1,"id":"cc-s-51015","channels":["public/standards"],
+ "stage":"published","edition":"1","title":"My Standard"}
+ -->
+
+## CC/S 51015
+
+| Field | Value |
+|---|---|
+| Document | cc-s-51015 |
+| Edition | 1 |
+| Status | published |
+| Channels | public/standards |
+```
+
+The `content-hash` on the first line enables incremental aggregation — unchanged
+releases are skipped. The `mn-release-metadata` JSON block (inside an HTML comment)
+is parsed by `actions-mn/aggregate` for channel filtering and indexing.
+
+=== Release action inputs
+
+[width="100%",cols="2,1,3"]
+|===
+| Input | Default | Description
+
+| `source-path` | `.` | Source path containing the metanorma configuration
+| `output-dir` | `_site` | Output directory containing compiled documents
+| `release-config` | `metanorma.release.yml` | Release manifest file
+| `default-visibility` | `public` | Default visibility for unlisted documents (`public`, `private`, or `members`)
+| `force` | `false` | Force release even if content hash matches
+| `force-replace` | `''` | Comma-separated doc IDs or glob patterns to force-replace (deletes and recreates specific releases)
+| `include-pattern` | `*` | Glob pattern to filter documents for release
+| `stages` | `''` | Comma-separated stages to release. Empty = all.
+| `channels` | `''` | Override channels for all documents. Empty = use manifest.
+| `concurrency` | `4` | Max parallel document processing
+| `token` | `${{ github.token }}` | GitHub token for creating releases
+|===
+
+=== Force-replacing releases
+
+Published releases are immutable by default — the action will not overwrite an
+existing release. To selectively re-release a specific document (e.g. to fix
+bad metadata), use the `force-replace` input:
+
+[source,yml]
+----
+- uses: actions-mn/release@v1
+  with:
+    force-replace: 'cc-s-51015'       # exact doc ID
+    # or: force-replace: 'cc-s-*'     # glob pattern
+    token: ${{ secrets.GITHUB_TOKEN }}
+----
+
+Only matched documents are deleted and recreated. Other documents in the same
+repo are completely unaffected.
+
+=== File routing
+
+`actions-mn/aggregate` supports three output structures via `file-routing`:
+
+`flat` (default):: All files in `output-dir/`
+`by-doctype`:: `{output-dir}/{doctype}/` subdirectories
+`by-format`:: `{output-dir}/{ext}/` subdirectories
+
+=== Generated index
+
+The aggregate action writes `index.json` to the output directory:
+
+[source,json]
+----
+{
+  "version": 1,
+  "generatedAt": "2026-05-13T06:00:00Z",
+  "parameters": {
+    "organizations": ["MyOrg"],
+    "channels": ["public/standards"],
+    "topic": "metanorma-release"
+  },
+  "summary": {
+    "repoCount": 5,
+    "documentCount": 42,
+    "channelsFound": ["public/standards"]
+  },
+  "documents": [
+    {
+      "id": "cc-s-51015",
+      "title": "My Standard",
+      "channels": ["public/standards"],
+      "files": [
+        {"name": "cc-s-51015.html", "path": "cc-s-51015.html"},
+        {"name": "cc-s-51015.pdf", "path": "cc-s-51015.pdf"}
+      ]
+    }
+  ]
+}
+----
 
 
 .`.github/workflows/generate.yml` file for generating a Metanorma site and deploying it to GitHub Pages

--- a/_posts/2026-05-13-channel-based-publication.adoc
+++ b/_posts/2026-05-13-channel-based-publication.adoc
@@ -1,0 +1,271 @@
+---
+layout: post
+title: "Channel-based publication for Metanorma: safe, declarative, zero-config"
+date: 2026-05-13
+categories: [release,pipeline,architecture]
+
+authors:
+- name: Ronald Tse
+  email: ronald.tse@ribose.com
+  social_links:
+  - https://github.com/ronaldtse
+
+excerpt: >-
+  A new channel-based publication architecture for Metanorma that ensures
+  documents only appear on the intended portals, with pattern-based manifests
+  that require zero per-document configuration.
+---
+
+== The problem: a single firehose
+
+When you publish dozens of document types — standards, reports, advisories,
+directives — from multiple repositories, a single release stream doesn't work.
+A portal has to download *every* release from *every* repo just to figure out
+which ones are relevant. And worse, without careful gating, a working draft or
+an internal document can leak to a public portal.
+
+We needed an architecture that is:
+
+. **Safe** — unpublished or internal documents *cannot* appear on public portals
+. **Declarative** — channels are assigned by pattern, not per-document configuration
+. **Zero-config** — adding a new document should not require manifest updates
+. **Auditable** — channel assignments are visible in the release metadata
+
+== The architecture
+
+The Metanorma publication system has four components:
+
+```
+Author         CI/CD           GitHub          Portal
+sources/       actions-mn/     Releases        actions-mn/
+*.adoc    →    site-gen   →   per-document →   aggregate    →  Jekyll site
+               + release       releases         index.json
+```
+
+[width="100%",cols="1,2,2"]
+|===
+| Component | Role | Repo
+
+| `actions-mn/site-gen`
+| Compiles AsciiDoc → HTML/PDF/XML/RXL
+| Per-document repo
+
+| `actions-mn/release`
+| Publishes compiled docs as GitHub Releases with channel metadata
+| Per-document repo
+
+| GitHub Releases
+| Stores per-document release artifacts + metadata
+| GitHub
+
+| `actions-mn/aggregate`
+| Discovers, filters, downloads, indexes released docs
+| Portal repo
+|===
+
+== Channels: audience + category
+
+A channel is an `audience/category` pair:
+
+- **audience**: `public`, `members`, or `internal` — determines access scope
+- **category**: free-form identifier — determines routing within a portal
+
+```
+public/standards        ← public audience, standards category
+members/internal-review ← members audience, internal-review category
+internal/working-draft  ← internal audience, never aggregated
+```
+
+The publisher sets the channel. The aggregator filters by it. The aggregator
+*cannot* override or discover channels the publisher didn't assign.
+
+== Three-layer safety model
+
+```
+Layer 1: Publisher gate (manifest)
+  → Unmatched documents = private (not released)
+  → "If it's not in the manifest, it doesn't exist."
+
+Layer 2: Channel assignment (release action)
+  → Pattern → channel mapping is authoritative
+  → "The publisher decides the channel. Period."
+
+Layer 3: Aggregation filter (aggregate action)
+  → Portal declares which channels it wants
+  → "The portal sees only what it asks for."
+```
+
+The critical rule: **never** set `defaults.visibility: public` in production
+manifests. When a document doesn't match any pattern, it defaults to private
+and no release is created.
+
+== Pattern-based manifests: zero per-document config
+
+Instead of listing every document individually, use patterns based on document
+ID conventions:
+
+```yaml
+# metanorma.release.yml
+documents:
+  - pattern: "cc-s-*"
+    channels: [public/standards]
+  - pattern: "cc-r-*"
+    channels: [public/reports]
+  - pattern: "cc-a-*"
+    channels: [public/admin]
+  - pattern: "cc-adv-*"
+    channels: [public/advisories]
+```
+
+When an author adds a new document like `cc-s-51020`, the pattern `cc-s-*`
+automatically assigns it to `public/standards`. No manifest update needed.
+
+For single-document repos or exceptions, use `source` instead:
+
+```yaml
+documents:
+  - source: sources/cc-10001.adoc
+    channels: [public/directives]
+```
+
+Stage gating adds an extra safety layer:
+
+```yaml
+documents:
+  - pattern: "cc-s-*"
+    stages: [published]
+    channels: [public/standards]
+```
+
+With this constraint, working drafts and committee drafts never create a GitHub
+Release — only the `published` stage triggers publication.
+
+== Publication flow
+
+```
+Author pushes to main
+         │
+         ▼
+site-gen: Compile AsciiDoc → HTML, PDF, XML, RXL
+         │
+         ▼
+release action:
+  1. Extract RXL         → Parse document metadata (ID, title, stage, edition)
+  2. Load manifest       → metanorma.release.yml → channel + visibility policy
+  3. Filter              → Pattern match + stage filter
+  4. Detect changes      → Content hash vs. last release
+  5. Package             → Zip with canonical filenames
+  6. Publish             → Create/update GitHub Release with metadata
+         │
+         ▼
+GitHub Release per document:
+  - Assets: cc-s-51015-ed1.zip (HTML+PDF+XML+RXL)
+  - Body: content-hash + mn-release-metadata JSON (channels, version, stage)
+         │
+         ▼
+aggregate action:
+  1. Discover repos      → Topic search or explicit list
+  2. Check manifest      → .metanorma/channels.yml → skip if no overlap
+  3. Fetch releases      → Paginated, with ETag caching
+  4. Parse metadata      → mn-release-metadata JSON from release body
+  5. Filter              → Channel + stage matching
+  6. Dedup               → Content-hash comparison → skip unchanged
+  7. Download + extract  → Zip → files, canonicalize filenames
+  8. Route files         → flat / by-doctype / by-format
+  9. Generate index      → index.json with full document metadata
+         │
+         ▼
+Portal (Jekyll) renders HTML pages from aggregated documents
+```
+
+== Release metadata
+
+Each GitHub Release carries structured metadata in its body:
+
+```
+content-hash:abc123...
+
+<!-- mn-release-metadata
+{"version":1,"id":"cc-s-51015",
+ "channels":["public/standards"],"stage":"published",
+ "edition":"1","title":"CalConnect Standard 51015"}
+ -->
+
+## CC/A 51015
+| Channels | public/standards |
+```
+
+The `mn-release-metadata` JSON block (inside an HTML comment) is machine-
+parseable by downstream consumers. The `content-hash` on the first line enables
+incremental aggregation — unchanged releases are skipped entirely.
+
+== The CalConnect channel registry
+
+CalConnect uses five public channels for its document types:
+
+[width="100%",cols="2,1,2,3"]
+|===
+| Channel | Audience | Document IDs | Description
+
+| `public/standards`
+| Public
+| `cc-s-*`
+| Published CalConnect Standards
+
+| `public/reports`
+| Public
+| `cc-r-*`
+| Conference, roundtable, IOP test reports
+
+| `public/admin`
+| Public
+| `cc-a-*`
+| Administrative documents
+
+| `public/advisories`
+| Public
+| `cc-adv-*`
+| Advisories
+
+| `public/directives`
+| Public
+| `cc-dir-*`
+| CalConnect directives
+|===
+
+== Migration path
+
+For existing Metanorma repositories, migration follows three steps:
+
+. **Update `metanorma.release.yml`** — replace explicit source lists with
+  pattern-based channel assignments
+. **Add `.metanorma/channels.yml`** — declare which channels the repo publishes
+  (enables efficient discovery by aggregators)
+. **Force re-release** — trigger a new release to add channel metadata to
+  existing documents
+
+For portals, migration means switching from source-based builds to
+`actions-mn/aggregate`:
+
+```yaml
+- uses: actions-mn/aggregate@v1
+  with:
+    organizations: CalConnect
+    topic: metanorma-release
+    channels: 'public/standards,public/reports'
+    output-dir: _site/cc
+    cache-dir: .cache/mn-aggregate
+    token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+== Result
+
+- **Authors** add a document, push to main. It appears on the right portal
+  automatically.
+- **Portal maintainers** declare which channels they want. They only see
+  documents published to those channels.
+- **Safety** is enforced at every layer: publisher, channel assignment, and
+  aggregation filter. An unlisted document is invisible. Period.
+
+The channel system is available now in `actions-mn/release@v1` and
+`actions-mn/aggregate@v1`.


### PR DESCRIPTION
Adds comprehensive documentation for the Metanorma channel-based publication architecture:

- **Blog post** (`_posts/2026-05-13-channel-based-publication.adoc`): Architecture overview covering the three-layer safety model, pattern-based manifests, and publication flow
- **CI/CD docs** (`_pages/install/cicd.adoc`): Full documentation of `actions-mn/release` + `actions-mn/aggregate` pipeline including channels, manifests, workflow setup, release metadata protocol, force-replace, file routing, and generated index

This documents the new publication system deployed to production at standards.calconnect.org (189 documents, 51 repos, 5 channels).